### PR TITLE
ENH: snapgene output format added

### DIFF
--- a/src/GslCore/Ape.fs
+++ b/src/GslCore/Ape.fs
@@ -46,7 +46,7 @@ FEATURES             Location/Qualifiers
 
         sprintf "ORIGIN\n" |> w
         
-        a.Sequence().arr
+        a.Sequence()
         |> formatGB
         |> w
 

--- a/src/GslCore/Ape.fs
+++ b/src/GslCore/Ape.fs
@@ -1,30 +1,17 @@
 ﻿module ape
 
 open System.IO
-open System.Text
 open System
 open commonTypes
 open constants
 open Amyris.Bio.utils
 open utils
 open Amyris.Dna
+open Genbank
         
-/// Format a dna sequence in genbank human readable form
-let formatGB (dna : char array) =
-    let rows = seq {0..60..dna.Length} |> Seq.map (fun i -> i,dna.[i..(min (i+59) (dna.Length-1))]) |> Array.ofSeq
-    let rowsSplit (i:int,row:char array) =
-        seq {0..10..row.Length-1} |> Seq.map (fun i -> new String(row.[i..(min (i+9) (row.Length-1))]))
-            |> fun x -> i,(String.Join (" ",Array.ofSeq x))
-    let tb = new StringBuilder()
-    for i,row in (rows |> Array.map (rowsSplit)) do
-        tb.AppendLine(sprintf "%9d %s" (i+1) row) |> ignore
-    tb.Append("//\n") |> ignore
-    tb.ToString()
-    
 /// Emit APE (genbank) format
 ///  outDir : string   tag: string  prefix for files  assemblies : List of AssemblyOut
 let dumpAPE (outDir:string) (tag:string) (assemblies : DnaAssembly list) =
-    let mon = [| "JAN" ; "FEB" ; "MAR" ; "APR" ; "MAY" ; "JUN" ; "JUL" ; "AUG" ; "SEP" ; "OCT"; "NOV" ; "DEC" |]
     for a in assemblies do
         let path = sprintf "%s.%d.ape" tag (match a.id with None -> failwith "ERROR: unassigned assembly id" | Some(i) -> i )
                         |> opj outDir

--- a/src/GslCore/CommandConfig.fs
+++ b/src/GslCore/CommandConfig.fs
@@ -80,7 +80,7 @@ let builtinCmdLineArgs =
 
         {spec=
             {name = "version"; param = []; alias = [];
-             desc = "print verison information"}
+             desc = "print version information"}
          proc = fun _ opts ->
             printfn "GSL compiler version %s" version
             opts};

--- a/src/GslCore/CoreOutputProviders.fs
+++ b/src/GslCore/CoreOutputProviders.fs
@@ -1,9 +1,9 @@
 ﻿module CoreOutputProviders
-open Amyris.Bio
 open PluginTypes
 open commandConfig
 open cloneManager
 open ape
+open snapgene
 open dumpFlat
 open commonTypes
 open System.IO
@@ -93,6 +93,23 @@ let apeOutputPlugin =
         (ApeOutputProvider(None))
 
 
+type SnapGeneOutputProvider (outParams) =
+    inherit ConfigurableOutputProvider<(string*string)>(outParams)
+    with
+    override x.ArgSpec =
+        {name = "snapgene"; param = ["outDir"; "prefix"]; alias = [];
+         desc = "write Snapgene output to prefix_##.dna to outDir\n(http://www.snapgene.com/products/snapgene_viewer/)"}
+    override x.UseArg(arg) =
+        SnapGeneOutputProvider(Some(arg.values.[0], arg.values.[1]))
+        :> IOutputFormat
+    override x.DoOutput((path,tag), data) = dumpSnapgene path tag data.assemblies data.primers
+
+let snapGeneOutputPlugin =
+    outputPlugin
+        "Snapgene"
+        (Some "Snapgene output format provider.")
+        (SnapGeneOutputProvider(None))
+
  /// Create output file with user or algorithm documentation of the designs
 let private dumpDocStrings (path:string) (assemblies:DnaAssembly list) =
     use outF = new StreamWriter(path)
@@ -145,6 +162,7 @@ let basicOutputPlugins = [
     flatFileOutputPlugin;
     cloneManagerOutputPlugin;
     apeOutputPlugin;
+    snapGeneOutputPlugin;
     docstringOutputPlugin;
     primerOutputPlugin;
 ]

--- a/src/GslCore/Genbank.fs
+++ b/src/GslCore/Genbank.fs
@@ -2,13 +2,14 @@
 /// common routines for emitting Genbank format
 open System.Text
 open System
+open Amyris.Dna
 
 /// Format a dna sequence in genbank human readable form
-let formatGB (dna : char array) =
+let formatGB (dna : Dna) =
     let rows = seq {0..60..dna.Length} |> Seq.map (fun i -> i,dna.[i..(min (i+59) (dna.Length-1))]) |> Array.ofSeq
-    let rowsSplit (i:int,row:char array) =
-        seq {0..10..row.Length-1} |> Seq.map (fun i -> new String(row.[i..(min (i+9) (row.Length-1))]))
-            |> fun x -> i,(String.Join (" ",Array.ofSeq x))
+    let rowsSplit (i:int,row:Dna) =
+        seq {0..10..row.Length-1} |> Seq.map (fun i -> row.[i..(min (i+9) (row.Length-1))])
+            |> fun x -> i,(String.Join (" ",[| for d in x -> d.ToString()|]))
     let tb = new StringBuilder()
     for i,row in (rows |> Array.map (rowsSplit)) do
         tb.AppendLine(sprintf "%9d %s" (i+1) row) |> ignore

--- a/src/GslCore/Genbank.fs
+++ b/src/GslCore/Genbank.fs
@@ -1,0 +1,19 @@
+﻿module Genbank
+/// common routines for emitting Genbank format
+open System.Text
+open System
+
+/// Format a dna sequence in genbank human readable form
+let formatGB (dna : char array) =
+    let rows = seq {0..60..dna.Length} |> Seq.map (fun i -> i,dna.[i..(min (i+59) (dna.Length-1))]) |> Array.ofSeq
+    let rowsSplit (i:int,row:char array) =
+        seq {0..10..row.Length-1} |> Seq.map (fun i -> new String(row.[i..(min (i+9) (row.Length-1))]))
+            |> fun x -> i,(String.Join (" ",Array.ofSeq x))
+    let tb = new StringBuilder()
+    for i,row in (rows |> Array.map (rowsSplit)) do
+        tb.AppendLine(sprintf "%9d %s" (i+1) row) |> ignore
+    tb.Append("//\n") |> ignore
+    tb.ToString()
+    
+
+let mon = [| "JAN" ; "FEB" ; "MAR" ; "APR" ; "MAY" ; "JUN" ; "JUL" ; "AUG" ; "SEP" ; "OCT"; "NOV" ; "DEC" |]

--- a/src/GslCore/GslCore.fsproj
+++ b/src/GslCore/GslCore.fsproj
@@ -76,6 +76,8 @@
     <Compile Include="CommonTypes.fs" />
     <Compile Include="CommandConfig.fs" />
     <Compile Include="CloneManager.fs" />
+    <Compile Include="Genbank.fs" />
+    <Compile Include="Snapgene.fs" />
     <Compile Include="Ape.fs" />
     <Compile Include="PrimerDump.fs" />
     <Compile Include="DumpFlat.fs" />

--- a/src/GslCore/Ryse.fs
+++ b/src/GslCore/Ryse.fs
@@ -379,14 +379,16 @@ let mapRyseLinkers
                     printVerbose
                         "countRyseLinkersNeeded in phase II start with 1 for final leading 0 linker (note 9 linker not included in count)"
                     let linkersReq = countRyseLinkersNeeded printVerbose 1 tl
-                    printVerbose (sprintf
-                        "\n\n#############################################\npart 2 of megastitch - %d linkers required, using %A\n"
-                        linkersReq (Seq.take linkersReq allLinkers2 |> List.ofSeq) )
 
+                    // check this first
                     if linkersReq > allLinkers2.Length then
                         failwithf
                             "mapRyseLinkers - need %d linkers to finish, only %d available %A\n"
                             linkersReq allLinkers2.Length errorDesc
+
+                    printVerbose (sprintf
+                        "\n\n#############################################\npart 2 of megastitch - %d linkers required, using %A\n"
+                        linkersReq (Seq.take linkersReq allLinkers2 |> List.ofSeq) )
 
                     // Flipping part around, but only for marker case.
                     // Should this also happen for the regular parts?  Must be dealt with elsewhere ;(

--- a/src/GslCore/Snapgene.fs
+++ b/src/GslCore/Snapgene.fs
@@ -1,0 +1,127 @@
+﻿module snapgene
+
+open System.IO
+open System
+open commonTypes
+open constants
+open Amyris.Bio.utils
+open utils
+open Amyris.Dna
+open Genbank
+        
+/// Emit Snapgene (genbank) format
+///  outDir : string   tag: string  prefix for files  assemblies : List of AssemblyOut
+let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (primers:DivergedPrimerPair list list option) =
+    // pair up the primer list (if they exist) with the matching assembly
+    let assemWithPrimers = ( 
+                                match primers with
+                                | Some p -> p
+                                | None -> List.init assemblies.Length (fun _ -> [])
+                            ) 
+                            |> List.zip assemblies
+
+    for (a,primers) in assemWithPrimers do
+
+        let path = sprintf "%s.%d.dna" tag (match a.id with None -> failwith "ERROR: unassigned assembly id" | Some(i) -> i )
+                        |> opj outDir
+        printf "Writing snapgene output to dir=%s tag=%s path=%s\n" outDir tag path
+
+
+        use outF = new StreamWriter(path)
+        let w (s:string) = outF.Write(s)
+        
+        let locusName = sprintf "%s_snapgene_output" tag
+        let totLength = a.dnaParts |> List.map (fun p -> p.dna.Length) |> Seq.sum
+        let now = DateTime.Now
+        sprintf "LOCUS       %-22s %d bp ds-DNA     linear   SYN %2d-%s-%d
+DEFINITION  .
+ACCESSION   .
+VERSION     .
+KEYWORDS    .
+SOURCE      synthetic DNA construct
+  ORGANISM  synthetic DNA construct
+COMMENT
+REFERENCE   1  (bases 1 to %d)
+  AUTHORS   .
+  TITLE     Direct Submission
+  JOURNAL   Exported %s %2d, %d from SnapGene Viewer 4.0.5
+            http://www.snapgene.com
+FEATURES             Location/Qualifiers
+     source          1..%d
+                     /organism=\"synthetic DNA construct\"
+                     /mol_type=\"other DNA\"
+                     /note=\"color: #ffffff\"
+"           "Exported" // snapgene fails to color anything if it's named anything else locusName 
+            totLength 
+            now.Day (mon.[now.Month-1]) now.Year 
+            totLength 
+            (mon.[now.Month-1]) now.Day now.Year 
+            totLength
+        |> w
+
+        for p in a.dnaParts do
+            let colorFwd = match p.sliceType with 
+                            | REGULAR -> 
+                                match p.breed with
+                                | Breed.B_UPSTREAM -> "#009933"
+                                | Breed.B_DOWNSTREAM -> "#009933"
+                                | Breed.B_PROMOTER -> "#3399FF"
+                                | Breed.B_FUSABLEORF -> "#FF0000"
+                                | Breed.B_GS -> "#FF3300"
+                                | Breed.B_GST -> "#FF6600"
+                                | Breed.B_INLINE -> "#99CCFF"
+                                | Breed.B_TERMINATOR -> "#000066"
+                                | Breed.B_VIRTUAL -> "#FF0066"
+                                | Breed.B_LINKER -> "#996633"
+                                | Breed.B_MARKER -> "#336600"
+                                | Breed.B_X -> "#000000"
+                            | LINKER -> "#FF0000"
+                            | MARKER -> "yellow" 
+                            | INLINEST -> "green" 
+                            | FUSIONST -> "red"
+            //let colorRev = match p.sliceType with | REGULAR -> "#0000F0" | LINKER -> "#D00000" 
+            //                                      | MARKER -> "yellow" | INLINEST -> "green" | FUSIONST ->"red"
+            let colorRev = colorFwd
+            let range = sprintf (if p.destFwd then "%A..%A" else "complement(%A..%A)") (zero2One p.destFr) (zero2One p.destTo)
+            let label = 
+                        (if p.sliceName <> "" then 
+                            p.sliceName 
+                         else if p.description <> "" then 
+                            p.description 
+                         else (ambId p.id))  
+            sprintf "     misc_feature    %s
+                     /label=\"%s\"
+                     /note=\"%s\"
+                     /note=\"color: %s; direction: %s\"\n"
+                        range 
+                        label
+                        label
+                         (if p.destFwd then colorFwd else colorRev)
+                         (if p.destFwd then "RIGHT" else "LEFT")
+            |> w
+
+        for pp in primers do 
+            match pp with
+            | GAP -> () // nothing to emit
+            | DPP(dpp) ->
+                if dpp.fwd.Primer.Length > 0 then
+                    let left = a.Sequence().IndicesOf(dpp.fwd.Primer) |> Seq.head
+                    let right = left + dpp.fwd.Primer.Length-1
+                    sprintf "     primer_bind     %A..%A
+                     /note=\"%s_Fwd\"
+                     /note=\"color: #a020f0; direction: RIGHT\"\n" (left+1) (right+1)  dpp.name
+                    |> w
+
+                if dpp.rev.Primer.Length > 0 then
+                    let left = a.Sequence().IndicesOf(dpp.rev.Primer.RevComp()) |> Seq.head
+                    let right = left + dpp.rev.Primer.Length-1
+                    sprintf "     primer_bind     complement(%A..%A)
+                     /note=\"%s_rev\"
+                     /note=\"color: #a020f0; direction: LEFT\"\n" (left+1) (right+1) dpp.name
+                    |> w
+
+        sprintf "ORIGIN\n" |> w
+        
+        a.Sequence().arr
+        |> formatGB
+        |> w

--- a/src/GslCore/Snapgene.fs
+++ b/src/GslCore/Snapgene.fs
@@ -23,7 +23,7 @@ let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (p
 
         let path = sprintf "%s.%d.dna" tag 
                     (match a.id with 
-                        | None -> failwith "unassigned assembly id in %s" a.name
+                        | None -> failwithf "unassigned assembly id in %s" a.name
                         | Some(i) -> i 
                     )
                     |> opj outDir
@@ -33,7 +33,8 @@ let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (p
         use outF = new StreamWriter(path)
         let w (s:string) = outF.Write(s)
         
-        let locusName = sprintf "%s_snapgene_output" tag
+        // "Exported" // snapgene fails to color anything if it's named anything else locusName 
+        let locusName = sprintf "Exported GSL %s" tag
         let totLength = a.dnaParts |> List.map (fun p -> p.dna.Length) |> Seq.sum
         let now = DateTime.Now
         (* // constraints on header format per SnapGene direct correspandance
@@ -56,14 +57,15 @@ COMMENT
 REFERENCE   1  (bases 1 to %d)
   AUTHORS   .
   TITLE     Direct Submission
-  JOURNAL   Exported %s %2d, %d from SnapGene Viewer 4.0.5
+  JOURNAL   Exported %s %2d, %d from GSL SnapGene generator
+            http://pubs.acs.org/doi/abs/10.1021/acssynbio.5b00194
             http://www.snapgene.com
 FEATURES             Location/Qualifiers
      source          1..%d
                      /organism=\"synthetic DNA construct\"
                      /mol_type=\"other DNA\"
                      /note=\"color: #ffffff\"
-"           "Exported" // snapgene fails to color anything if it's named anything else locusName 
+"           locusName 
             totLength  // header line locus length
             now.Day (mon.[now.Month-1]) now.Year  // header line date
             totLength  // length for REFERENCE line

--- a/src/GslCore/Snapgene.fs
+++ b/src/GslCore/Snapgene.fs
@@ -13,17 +13,20 @@ open Genbank
 ///  outDir : string   tag: string  prefix for files  assemblies : List of AssemblyOut
 let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (primers:DivergedPrimerPair list list option) =
     // pair up the primer list (if they exist) with the matching assembly
-    let assemWithPrimers = ( 
-                                match primers with
-                                | Some p -> p
-                                | None -> List.init assemblies.Length (fun _ -> [])
-                            ) 
-                            |> List.zip assemblies
+    let assemWithPrimers =  
+        match primers with
+        | Some p -> p
+        | None -> List.init assemblies.Length (fun _ -> [])
+        |> List.zip assemblies
 
     for (a,primers) in assemWithPrimers do
 
-        let path = sprintf "%s.%d.dna" tag (match a.id with None -> failwith "ERROR: unassigned assembly id" | Some(i) -> i )
-                        |> opj outDir
+        let path = sprintf "%s.%d.dna" tag 
+                    (match a.id with 
+                        | None -> failwith "unassigned assembly id in %s" a.name
+                        | Some(i) -> i 
+                    )
+                    |> opj outDir
         printf "Writing snapgene output to dir=%s tag=%s path=%s\n" outDir tag path
 
 
@@ -33,6 +36,15 @@ let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (p
         let locusName = sprintf "%s_snapgene_output" tag
         let totLength = a.dnaParts |> List.map (fun p -> p.dna.Length) |> Seq.sum
         let now = DateTime.Now
+        (* // constraints on header format per SnapGene direct correspandance
+
+        1) LOCUS must contain "Exported".
+        2) Last reference TITLE must be "Direct Submission".
+        3) Last reference JOURNAL must contain "SnapGene".
+            (In the past we did require it contain "Exported from SnapGene" or "Exported from SnapGene Viewer" 
+            but we recently relaxed that requirement. The change is in version 4.1.)
+        *)
+
         sprintf "LOCUS       %-22s %d bp ds-DNA     linear   SYN %2d-%s-%d
 DEFINITION  .
 ACCESSION   .
@@ -52,43 +64,42 @@ FEATURES             Location/Qualifiers
                      /mol_type=\"other DNA\"
                      /note=\"color: #ffffff\"
 "           "Exported" // snapgene fails to color anything if it's named anything else locusName 
-            totLength 
-            now.Day (mon.[now.Month-1]) now.Year 
-            totLength 
-            (mon.[now.Month-1]) now.Day now.Year 
-            totLength
+            totLength  // header line locus length
+            now.Day (mon.[now.Month-1]) now.Year  // header line date
+            totLength  // length for REFERENCE line
+            (mon.[now.Month-1]) now.Day now.Year  // Journal export date
+            totLength // source length line
         |> w
 
         for p in a.dnaParts do
-            let colorFwd = match p.sliceType with 
-                            | REGULAR -> 
-                                match p.breed with
-                                | Breed.B_UPSTREAM -> "#009933"
-                                | Breed.B_DOWNSTREAM -> "#009933"
-                                | Breed.B_PROMOTER -> "#3399FF"
-                                | Breed.B_FUSABLEORF -> "#FF0000"
-                                | Breed.B_GS -> "#FF3300"
-                                | Breed.B_GST -> "#FF6600"
-                                | Breed.B_INLINE -> "#99CCFF"
-                                | Breed.B_TERMINATOR -> "#000066"
-                                | Breed.B_VIRTUAL -> "#FF0066"
-                                | Breed.B_LINKER -> "#996633"
-                                | Breed.B_MARKER -> "#336600"
-                                | Breed.B_X -> "#000000"
-                            | LINKER -> "#FF0000"
-                            | MARKER -> "yellow" 
-                            | INLINEST -> "green" 
-                            | FUSIONST -> "red"
-            //let colorRev = match p.sliceType with | REGULAR -> "#0000F0" | LINKER -> "#D00000" 
-            //                                      | MARKER -> "yellow" | INLINEST -> "green" | FUSIONST ->"red"
-            let colorRev = colorFwd
+            let colorFwd = 
+                match p.sliceType with 
+                | REGULAR -> 
+                    match p.breed with
+                    | Breed.B_UPSTREAM -> "#009933"
+                    | Breed.B_DOWNSTREAM -> "#009933"
+                    | Breed.B_PROMOTER -> "#3399FF"
+                    | Breed.B_FUSABLEORF -> "#FF0000"
+                    | Breed.B_GS -> "#FF3300"
+                    | Breed.B_GST -> "#FF6600"
+                    | Breed.B_INLINE -> "#99CCFF"
+                    | Breed.B_TERMINATOR -> "#000066"
+                    | Breed.B_VIRTUAL -> "#FF0066"
+                    | Breed.B_LINKER -> "#996633"
+                    | Breed.B_MARKER -> "#336600"
+                    | Breed.B_X -> "#000000"
+                | LINKER -> "#FF0000"
+                | MARKER -> "yellow" 
+                | INLINEST -> "green" 
+                | FUSIONST -> "red"
+            let colorRev = colorFwd // reserve possibility of different colors for different orientations but for now the same
             let range = sprintf (if p.destFwd then "%A..%A" else "complement(%A..%A)") (zero2One p.destFr) (zero2One p.destTo)
             let label = 
-                        (if p.sliceName <> "" then 
-                            p.sliceName 
-                         else if p.description <> "" then 
-                            p.description 
-                         else (ambId p.id))  
+                if p.sliceName <> "" then 
+                    p.sliceName 
+                 else if p.description <> "" then 
+                    p.description 
+                 else (ambId p.id)
             sprintf "     misc_feature    %s
                      /label=\"%s\"
                      /note=\"%s\"
@@ -96,32 +107,38 @@ FEATURES             Location/Qualifiers
                         range 
                         label
                         label
-                         (if p.destFwd then colorFwd else colorRev)
-                         (if p.destFwd then "RIGHT" else "LEFT")
+                        (if p.destFwd then colorFwd else colorRev)
+                        (if p.destFwd then "RIGHT" else "LEFT")
+            |> w
+
+        // Primer emission
+        let makeRange l r = sprintf "%A..%A" (l+1) (r+1) // +1 for human friendly coords
+        let complement s = sprintf "complement(%s)" s
+
+        let emitPrimer name isFwd (primer:Primer) =
+            let searchDna = if isFwd then primer.Primer else primer.Primer.RevComp()
+            // this isn't an ideal way to place primers but simpler than trying to infer coordinates during emission
+            // will break if there are multiple binding sites but that might be a good thing to alert user
+            let left = a.Sequence().IndicesOf(searchDna) |> Seq.head 
+            let right = left + primer.Primer.Length-1
+            sprintf "     primer_bind     %s 
+             /note=\"%s_%s\"
+             /note=\"color: #a020f0; direction: %s\"\n" 
+                (makeRange left right |> if isFwd then (id) else complement)  
+                name
+                (if isFwd then "fwd" else "rev")
+                (if isFwd then "RIGHT" else "LEFT")
             |> w
 
         for pp in primers do 
             match pp with
             | GAP -> () // nothing to emit
             | DPP(dpp) ->
-                if dpp.fwd.Primer.Length > 0 then
-                    let left = a.Sequence().IndicesOf(dpp.fwd.Primer) |> Seq.head
-                    let right = left + dpp.fwd.Primer.Length-1
-                    sprintf "     primer_bind     %A..%A
-                     /note=\"%s_Fwd\"
-                     /note=\"color: #a020f0; direction: RIGHT\"\n" (left+1) (right+1)  dpp.name
-                    |> w
+                if dpp.fwd.Primer.Length > 0 then emitPrimer dpp.name true dpp.fwd
+                if dpp.rev.Primer.Length > 0 then emitPrimer dpp.name false dpp.rev
 
-                if dpp.rev.Primer.Length > 0 then
-                    let left = a.Sequence().IndicesOf(dpp.rev.Primer.RevComp()) |> Seq.head
-                    let right = left + dpp.rev.Primer.Length-1
-                    sprintf "     primer_bind     complement(%A..%A)
-                     /note=\"%s_rev\"
-                     /note=\"color: #a020f0; direction: LEFT\"\n" (left+1) (right+1) dpp.name
-                    |> w
-
-        sprintf "ORIGIN\n" |> w
+        "ORIGIN\n" |> w
         
-        a.Sequence().arr
+        a.Sequence()
         |> formatGB
         |> w


### PR DESCRIPTION
This is the snapgene viewer implementation.  You can test it with the free snapgene viewer,  also works with the full snapgene tool.  Adds a primer binding region to the genbank output.  I've factored out the common code with the similar APE format but both tools have strange proprietary quirks that need custom formats. 