### PR TITLE
BUG: seamless design was using the seamlessTm for ampTm…

### DIFF
--- a/src/GslCore/DesignParams.fs
+++ b/src/GslCore/DesignParams.fs
@@ -18,7 +18,6 @@ let revisePP (p: PrimerParams) (arguments: string list) =
 
 type DesignParams =
    {targetTm: float<C>;
-    seamlessTm: float<C>; 
     seamlessOverlapTm: float<C>;
     pp: PrimerParams;
     overlapParams: PrimerParams; 
@@ -28,7 +27,6 @@ type DesignParams =
 let initialDesignParams =
    {pp = defaultParams;
     targetTm = ryseLinkerTargetDefault;
-    seamlessTm = seamlessTargetDefault;
     seamlessOverlapTm = seamlessTargetDefault;
     overlapParams = defaultParams;
     overlapMinLen = overlapMinLenDefault}
@@ -43,7 +41,6 @@ let updateDPFromPragma (p: Pragma) designParams =
         >>= (fun overlapParams -> ok {designParams with overlapParams = overlapParams})
     | "targettm", v::_ -> ok {designParams with targetTm = strToTempC v}
     | "minoverlaplen", v::_ -> ok {designParams with overlapMinLen = int v}
-    | "seamlesstm", v::_ -> ok {designParams with seamlessTm = strToTempC v}
     | "seamlessoverlaptm", v::_ -> ok {designParams with seamlessOverlapTm = strToTempC v}
     | "atpenalty", v::_ ->
         ok {designParams with pp = {designParams.pp with ATPenalty = float v * 1.0<C>}}

--- a/src/GslCore/PrimerCreation.fs
+++ b/src/GslCore/PrimerCreation.fs
@@ -2,7 +2,6 @@
 /// Support routines for primer design scenarios and primer generation for stitches
 open commonTypes
 open System
-open System.Text
 open constants // primer parameters
 open Amyris.Bio.primercore
 open Amyris.Bio
@@ -635,10 +634,9 @@ let designPrimers (opts:ParsedOptions) (linkedTree : DnaAssembly list) =
                     align = ANCHOR.CENTERLEFT;
                     strand = STRAND.TOP;
                     offset = 0;
-                    targetTemp = dp.seamlessTm;
+                    targetTemp = dp.targetTm; // was historically seamlessTm incorrectly till ~ 10/2017
                     sequencePenalties = None}
 
-                // primercore.oligoDesign false pen task
                 pdWrap false pen task
 
             else
@@ -648,9 +646,8 @@ let designPrimers (opts:ParsedOptions) (linkedTree : DnaAssembly list) =
                      align = ANCHOR.LEFT;
                      strand = STRAND.TOP;
                      offset = 0;
-                     targetTemp = dp.seamlessTm;
+                     targetTemp = dp.targetTm; // was historically seamlessTm incorrectly till ~ 10/2017
                      sequencePenalties = None}
-                //primercore.oligoDesign false pen task
                 pdWrap false pen task
 
         /// Called on success at finding fwd and reverse primers that can amplify the adjacent regions


### PR DESCRIPTION
From email:  Auditing some primer designs and Andrew noticed that GSL was way over-shooting the target Tm for some primer designs and it turns out there's a very ancient bug I wanted to propose fixing, but thought I should run by you first.    GSL maintains a targettm and a seamlesstm which are set by default to 60 and 68C respectively.   I think the original idea was that for seamless designs, you might want to target the *annealing* temperature and use the 68 number for a guide to length.   What the code actually does however is use the seamlessTm value for the *amplification* primer as well (bad code below),  and then uses the seamlessTm value as well for tuning the tails to get the annealing right.