### PR TITLE
ENH: snapgene shows primer_binding sites not primers unless sequence …

### DIFF
--- a/src/GslCore/Snapgene.fs
+++ b/src/GslCore/Snapgene.fs
@@ -125,10 +125,11 @@ FEATURES             Location/Qualifiers
             let right = left + primer.Primer.Length-1
             sprintf "     primer_bind     %s 
              /note=\"%s_%s\"
-             /note=\"color: #a020f0; direction: %s\"\n" 
+             /note=\"color: #a020f0; sequence: %s; direction: %s\"\n" 
                 (makeRange left right |> if isFwd then (id) else complement)  
                 name
                 (if isFwd then "fwd" else "rev")
+                primer.Primer.str
                 (if isFwd then "RIGHT" else "LEFT")
             |> w
 


### PR DESCRIPTION
…is emitted explicitly

Small patch to get snapgene to show primers rather than just primer binding sites.  It needs the sequence to be explicitly stated in the genbank feature