### PR TITLE
BUG: --helpPragmas needs to print post command config and pragma init

### DIFF
--- a/src/GslCore/CommandConfig.fs
+++ b/src/GslCore/CommandConfig.fs
@@ -88,9 +88,8 @@ let builtinCmdLineArgs =
         {spec=
             {name = "helpPragmas"; param = []; alias = [];
              desc = "print available pragmas"}
-         proc = fun _ opts ->
-            pragmaUsage()
-            opts};
+         proc = fun _ opts -> {opts with doHelpPragmas = true}
+        };
 
         {spec=
             {name = "quiet"; param = []; alias = [];
@@ -179,4 +178,5 @@ let defaultOpts:ParsedOptions =
     refList = false
     refDump = None
     listPlugins = false
+    doHelpPragmas = false
     }

--- a/src/GslCore/CommonTypes.fs
+++ b/src/GslCore/CommonTypes.fs
@@ -26,6 +26,7 @@ type ParsedOptions =
     refList : bool;
     refDump : string option;
     listPlugins: bool;
+    doHelpPragmas : bool
     }
 
 type DNAIntervalType = ANNEAL | RYSELINKER | AMP | SANDWICH

--- a/src/GslCore/Gslc.fs
+++ b/src/GslCore/Gslc.fs
@@ -140,6 +140,10 @@ let configureGslc unconfiguredPlugins argv =
             // FIXME: should eliminate global pragma storage
             pragmaTypes.finalizePragmas pluginPragmas
 
+            // fulfill this request only after we've processed all the plugins and determined full list of pragmas
+            if s.opts.doHelpPragmas then
+                pragmaTypes.pragmaUsage()
+
             Continue(s)
         with e ->
             Exit(1, Some(sprintf "An error occurred during configuration:\n%s" e.Message))


### PR DESCRIPTION
This is a fix for --helpPragmas problem.  Unfortunately I don't think it can be easily patched within the --helpPragmas config since it needs to wait for configuration to finish, then run, but I have added a flag to opts and this works correctly.