### PR TITLE
Split marker

### DIFF
--- a/src/GslCore/BasicMarkerProvider.fs
+++ b/src/GslCore/BasicMarkerProvider.fs
@@ -1,0 +1,110 @@
+﻿module BasicMarkerProvider
+open System
+open Amyris.Bio.biolib
+open constants
+open LegacyParseTypes
+open RefGenome
+open pragmaTypes
+open commonTypes
+open applySlices
+open Amyris.Bio
+open Amyris.ErrorHandling
+open Amyris.Dna
+open ryse
+open PluginTypes
+open DnaCreation
+open PluginTypes
+
+/// Default marker provider if nothing else better
+let jobScorerBasicMarkerProvider _ = Some 0.0<PluginScore>
+
+/// Expand a marker part into DNA pieces.
+/// Exception on failure.
+let expandMarkerPartIntoURA3
+    dnaSource
+    (dna:Dna)
+    (ppp:PPP) =
+
+    {id = None;
+     extId = None;
+     sliceName = getSliceName ppp;
+     uri = getUri ppp; // TODO: should this marker have a static URI we always assign here?
+     dna = dna;
+     sourceChr = "library";
+     sourceFr = 0<ZeroOffset>;
+     sourceTo = (dna.Length-1)*1<ZeroOffset>;
+     sourceFwd = true;
+     sourceFrApprox = false;
+     sourceToApprox = false;
+     // Don't assign coordinates to pieces until later when we
+     // decide how they are getting joined up
+     template = Some dna;
+     amplified = false;
+     destFr = 0<ZeroOffset>;
+     destTo = 0<ZeroOffset>;
+     destFwd = ppp.fwd;
+     description = "URA3 marker";
+     sliceType = MARKER;
+     dnaSource = dnaSource;
+     pragmas = ppp.pr;
+     breed = B_MARKER;
+     materializedFrom = Some(ppp);
+     annotations = []}
+
+/// Classic URA3 sequence that has always been hard coded into center of megastitches (from lib.fa)
+let basicURA3 = "GTTCATCATCTCATGGATCTGCACATGAACAAACACCAGAGTCAAACGACGTTGAAATTG\
+AGGCTACTGCGCCAATTGATGACAATACAGACGATGATAACAAACCGAAGTTATCTGATG\
+TAGAAAAGGATTAAAGATGCTAAGAGATAGTGATGATATTTCATAAATAATGTAATTCTA\
+TATATGTTAATTACCTTTTTTGCGAGGCATATTTATGGTGAAGGATAAGTTTTGACCATC\
+AAAGAAGGTTAATGTGGCTGTGGTTTCAGGGTCCATAAAGCTTTTCAATTCATCTTTTTT\
+TTTTTTGTTCTTTTTTTTGATTCCGGTTTCTTTGAAATTTTTTTGATTCGGTAATCTCCG\
+AGCAGAAGGAAGAACGAAGGAAGGAGCACAGACTTAGATTGGTATATATACGCATATGTG\
+GTGTTGAAGAAACATGAAATTGCCCAGTATTCTTAACCCAACTGCACAGAACAAAAACCT\
+GCAGGAAACGAAGATAAATCATGTCGAAAGCTACATATAAGGAACGTGCTGCTACTCATC\
+CTAGTCCTGTTGCTGCCAAGCTATTTAATATCATGCACGAAAAGCAAACAAACTTGTGTG\
+CTTCATTGGATGTTCGTACCACCAAGGAATTACTGGAGTTAGTTGAAGCATTAGGTCCCA\
+AAATTTGTTTACTAAAAACACATGTGGATATCTTGACTGATTTTTCCATGGAGGGCACAG\
+TTAAGCCGCTAAAGGCATTATCCGCCAAGTACAATTTTTTACTCTTCGAAGACAGAAAAT\
+TTGCTGACATTGGTAATACAGTCAAATTGCAGTACTCTGCGGGTGTATACAGAATAGCAG\
+AATGGGCAGACATTACGAATGCACACGGTGTGGTGGGCCCAGGTATTGTTAGCGGTTTGA\
+AGCAGGCGGCGGAAGAAGTAACAAAGGAACCTAGAGGCCTTTTGATGTTAGCAGAATTGT\
+CATGCAAGGGCTCCCTAGCTACTGGAGAATATACTAAGGGTACTGTTGACATTGCGAAGA\
+GCGACAAAGATTTTGTTATCGGCTTTATTGCTCAAAGAGACATGGGTGGAAGAGATGAAG\
+GTTACGATTGGTTGATTATGACACCCGGTGTGGGTTTAGATGACAAGGGAGACGCATTGG\
+GTCAACAGTATAGAACCGTGGATGATGTGGTCTCTACAGGATCTGACATTATTATTGTTG\
+GAAGAGGACTATTTGCAAAGGGAAGGGATGCTAAGGTAGAGGGTGAACGTTACAGAAAAG\
+CAGGCTGGGAAGCATATTTGAGAAGATGCGGCCAGCAAAACTAAAAAACTGTATTATAAG\
+TAAATGCATGTATACTAAACTCACAAATTAGAGCTTCAATTTAATTATATCAGTTATTAC\
+CCGGGAATCTCGGTCGTAATGATTTCTATAATGACGAAAAAAAAAAAATTGGAAAGAAAA\
+AGCTTCATGGCCTTTATAAAAAGGAACTATCCAATACCTCGCCAGAACCAAGTAACAGTA"
+
+type BasicURA3MarkerProvider = {
+        ura3:Dna option
+    } with
+       interface IMarkerProvider with
+            member __.ProvidedArgs() = []
+            member x.Configure(_) = x :> IMarkerProvider
+            member x.ConfigureFromOptions(_opts) = 
+                        {x with ura3 = Some (Dna(basicURA3)) } :> IMarkerProvider
+            member x.Setup(_) = x :> IMarkerProvider
+            member x.CreateDna (task:MarkerMaterializationTask) = 
+                expandMarkerPartIntoURA3 task.dnaSource x.ura3.Value task.ppp
+            member x.IsLegal m = m = "ura3" || m = "default"
+            member x.ListMarkers() = ["ura3"]
+            member x.ScoreJob = jobScorerBasicMarkerProvider
+        
+/// Original default URA3 behavior for materialized ### parts
+let basicMarkerProviderURA3 =
+   let x = {ura3=None}:BasicURA3MarkerProvider
+
+   {name = "classic ura3 dropin marker provider";
+    description = Some "Include default ura3 sequence in materialized ### sequences.";
+    behaviors =
+       [{name = None;
+         description = None;
+         behavior =
+            MarkerProvider(x :> IMarkerProvider)
+        }
+       ];
+    providesPragmas = [];
+    providesCapas = []};

--- a/src/GslCore/BasicMarkerProvider.fs
+++ b/src/GslCore/BasicMarkerProvider.fs
@@ -80,21 +80,19 @@ type BasicURA3MarkerProvider = {
             member x.Setup(_) = x :> IMarkerProvider
             member x.CreateDna (task:MarkerMaterializationTask) = 
                 expandMarkerPartIntoURA3 task.dnaSource x.ura3.Value task.ppp
-            member x.IsLegal m = m = "ura3" || m = "default"
+            member x.IsLegal m = m.ToLower() = "ura3" || m.ToLower() = "default"
             member x.ListMarkers() = ["ura3"]
             member x.ScoreJob = jobScorerBasicMarkerProvider
         
 /// Original default URA3 behavior for materialized ### parts
 let basicMarkerProviderURA3 =
-   let x = {ura3=None}:BasicURA3MarkerProvider
-
    {name = "classic ura3 dropin marker provider";
     description = Some "Include default ura3 sequence in materialized ### sequences.";
     behaviors =
        [{name = None;
          description = None;
          behavior =
-            MarkerProvider(x :> IMarkerProvider)
+            MarkerProvider({ura3=None})
         }
        ];
     providesPragmas = [];

--- a/src/GslCore/BasicMarkerProvider.fs
+++ b/src/GslCore/BasicMarkerProvider.fs
@@ -1,19 +1,10 @@
 ﻿module BasicMarkerProvider
-open System
-open Amyris.Bio.biolib
 open constants
 open LegacyParseTypes
-open RefGenome
-open pragmaTypes
 open commonTypes
-open applySlices
-open Amyris.Bio
-open Amyris.ErrorHandling
 open Amyris.Dna
-open ryse
 open PluginTypes
 open DnaCreation
-open PluginTypes
 
 /// Default marker provider if nothing else better
 let jobScorerBasicMarkerProvider _ = Some 0.0<PluginScore>

--- a/src/GslCore/GslCore.fsproj
+++ b/src/GslCore/GslCore.fsproj
@@ -96,6 +96,7 @@
     <Compile Include="ApplySlices.fs" />
     <Compile Include="ResolveExtPart.fs" />
     <Compile Include="DnaCreation.fs" />
+    <Compile Include="BasicMarkerProvider.fs" />
     <Compile Include="CoreOutputProviders.fs" />
     <Compile Include="JsonAssembly.fs" />
     <Compile Include="ProcessCmdLineArgs.fs" />

--- a/src/GslCore/GslcProcess.fs
+++ b/src/GslCore/GslcProcess.fs
@@ -58,12 +58,14 @@ let rec processGSL (s: ConfigurationState) gslText =
 let materializeDna (s:ConfigurationState) (assem:seq<Assembly>) =
     let opts, library, rgs = s.opts, s.ga.seqLibrary, s.ga.rgs
 
+    let markerProviders = s.plugins |> getAllProviders getMarkerProviders
+
     if opts.verbose then printf "Processing %d assemblies\n" (Seq.length assem)
 
     assem
     |> Seq.mapi (fun i a ->
         try
-            expandAssembly opts.verbose rgs library i a
+            expandAssembly opts.verbose markerProviders rgs library i a
             |> ok
         with e ->
             fail(exceptionToAssemblyMessage a e))

--- a/src/GslCore/Markers.fs
+++ b/src/GslCore/Markers.fs
@@ -43,3 +43,4 @@ let loadMarkers (libPath:string) =
 
 let legalMarkers path =
     loadMarkers path |> Set.map (fun halfMarker -> halfMarker.name)
+

--- a/src/GslCore/PluginTypes.fs
+++ b/src/GslCore/PluginTypes.fs
@@ -250,8 +250,8 @@ let configureBehaviorFromOpts opts b =
     | OutputFormat(f) -> {b with behavior = OutputFormat(f.ConfigureFromOptions(opts))}
     | AssemblyTransform(a) -> {b with behavior = AssemblyTransform(a.ConfigureFromOptions(opts))}
     | CodonProvider(c) -> {b with behavior = CodonProvider(c.ConfigureFromOptions(opts))}
+    | MarkerProvider(c) -> {b with behavior = MarkerProvider(c.ConfigureFromOptions(opts))}
     | AlleleSwapAA _
-    | MarkerProvider _
     | L2KOTitration _ -> b
 
 /// Data structure specifying one or more behaviors


### PR DESCRIPTION
  I am finally dealing with the fateful decision a long time ago to use a URA3 stuffer fragment when building the megastitch version of the assembly.   This has always freaked people out because their clone manager or APE output has a URA marker, though the thumper output format artfully reinserts the correct parts for building.  I've made a marker provider that is customizable so you can handle the insertion of that sequence more gracefully.  To mimic the default bevavior there's a basicura3 provider in GslCore but it does check the proposed marker against the list of known markers so by default it will break your workflow unless you provide a better marker provider which should be easy.  The GslCore code sort of has parts of the Amris marker support but it's not really used, so i could take a guess at what your provider would look like but probably best to write your own.   Happy to informally share the one I wrote which will look similar to yours.  Alternative is to make the basic provider more powerful but that involves breaking more things.   Open to any suggestions on how to move forward but I have something that will work well for us for now and wanted to at least share that.