### PR TITLE
BUG: on machines with 1 core, the leave one core for OS logic fails

### DIFF
--- a/src/GslCore/AstAlgorithms.fs
+++ b/src/GslCore/AstAlgorithms.fs
@@ -445,7 +445,8 @@ let foldmap
             assert (statesForNodes.Length = nodeArray.Length)
 
             let nCores = System.Environment.ProcessorCount
-            let useNCores = nCores - 1 // leave one for the OS
+            // leave one for the OS, make sure at least 1!
+            let useNCores = nCores - 1 |> max 1 
 
             Array.zip statesForNodes nodeArray
             |> PSeq.map (fun (inputState, n) ->


### PR DESCRIPTION
This bug can cause the following error on machines with a single core.  Patch ensures at least one core available to AstProcessing

```
Specified argument was out of the range of valid values.
Parameter name: degreeOfParallelism
```