### PR TITLE
BUG: extreme long inline sequences cause tuneTailOpt runaway Tm

### DIFF
--- a/src/GslCore/PrimerCreation.fs
+++ b/src/GslCore/PrimerCreation.fs
@@ -184,11 +184,11 @@ let tuneTails
     let annealTarget = 
         match firmMiddle with 
         | Some(x) -> 
-                if verbose then printfn "setAnnealTarget to firmMiddle=%A" x
-                x 
+            if verbose then printfn "setAnnealTarget to firmMiddle=%A" x
+            x 
         | None -> 
-                if verbose then printfn "setAnnealTarget to seamlessOverlapTm=%A" dp.seamlessOverlapTm
-                dp.seamlessOverlapTm
+            if verbose then printfn "setAnnealTarget to seamlessOverlapTm=%A" dp.seamlessOverlapTm
+            dp.seamlessOverlapTm
     //let annealTarget = dp.seamlessOverlapTm // Just use this,  rev/fwdTailLenFixed vars take care of constraining RYSE linkers
 
     // Find two positions f and r that create a better ovelap tm

--- a/src/GslCore/PrimerCreation.fs
+++ b/src/GslCore/PrimerCreation.fs
@@ -205,6 +205,8 @@ let tuneTails
     if verbose then
         printfn "tuneTailOpt: X=%d Y=%d\n template=%s" X Y fullTemplate.str
 
+    /// Maximum amount by which we can stray from ideal annealing term during tune tails search
+    let maxAnnealSearchDeviation = 10.0<C>
     /// Recursive optimization of the primer ends, adjusting lengths to get the amp / anneal and primer lengths optimized
     let rec tuneTailsOpt itersRemaining (state:TuneState) (seen':Set<TuneVector>) =
 
@@ -280,7 +282,7 @@ let tuneTails
                 | OligoOver(_) -> // cut something off
                     if state.fb>dp.pp.minLength then  yield CHOP_F_AMP
                     // Put guard on this to stop best anneal data running away to zero kelvin ;(
-                    if fwdTailLenFixed.IsNone && state.ft > fwdTailLenMin && state.bestAnnealDelta < 10.0<C> then 
+                    if fwdTailLenFixed.IsNone && state.ft > fwdTailLenMin && state.bestAnnealDelta < maxAnnealSearchDeviation then 
                         yield CHOP_F_ANNEAL
                 | OligoMax(_) -> // could slide or cut
                     if state.bestFwdDelta < 0.0<C> && state.fb>dp.pp.minLength then yield CHOP_F_AMP
@@ -297,7 +299,7 @@ let tuneTails
                             then yield CHOP_F_AMP
                         elif state.fb < fwd.body.Length then yield EXT_F_AMP
                         if state.bestAnnealDelta < 0.0<C> && state.ft > fwdTailLenMin then 
-                                yield CHOP_F_ANNEAL
+                            yield CHOP_F_ANNEAL
                         elif state.ft < fwdTailLenMax then yield EXT_F_ANNEAL
 
                         match sign state.bestAnnealDelta, sign state.bestFwdDelta with

--- a/src/GslCore/PrimerCreation.fs
+++ b/src/GslCore/PrimerCreation.fs
@@ -182,13 +182,13 @@ let tuneTails
 
     /// Target Tm for middle annealing part.  Cheat if it's a linker and we just want to keep this part (ideally) full length
     let annealTarget = 
-            match firmMiddle with 
-            | Some(x) -> 
-                    if verbose then printfn "setAnnealTarget to firmMiddle=%A" x
-                    x 
-            | None -> 
-                    if verbose then printfn "setAnnealTarget to seamlessOverlapTm=%A" dp.seamlessOverlapTm
-                    dp.seamlessOverlapTm
+        match firmMiddle with 
+        | Some(x) -> 
+                if verbose then printfn "setAnnealTarget to firmMiddle=%A" x
+                x 
+        | None -> 
+                if verbose then printfn "setAnnealTarget to seamlessOverlapTm=%A" dp.seamlessOverlapTm
+                dp.seamlessOverlapTm
     //let annealTarget = dp.seamlessOverlapTm // Just use this,  rev/fwdTailLenFixed vars take care of constraining RYSE linkers
 
     // Find two positions f and r that create a better ovelap tm


### PR DESCRIPTION
Have only seen this once in a hard to document test case but long inline sequences and challenging primer constraints cause tuneTailOpt to make extremely short amplification regions, which then approach 0 Kelvin melting temperatures eventually blowing up Tm cals on a zero length overlap.  This fix constraints the solution space so at least the Tm calcs won't blow up and crash.   Patch also adds some verbose mode only diagnostics to help next poor person dealing with this code.