### PR TITLE
Assembly tagging

### DIFF
--- a/docs/content/tagging.md
+++ b/docs/content/tagging.md
@@ -1,0 +1,36 @@
+# Tagging
+
+Tags are terms within namespaces that can be associated with assemblies using the `tag` pragma.
+
+```GSL
+// Example tag pragma, term red in the color namespace
+#tag color:red
+pTDH3>gERG10
+```
+
+Tags are transient pragmas that associate with the next emitted assembly.  Each tag consists of a namespace and term.  More than one namespace pair can be specified with each `#tag`.
+
+```GSL
+// Multiple tags for one assembly
+#tag color:red flavor:vanilla
+pTDH3>gERG10
+```
+
+Multiple tags may be specified on different lines leading up to an assembly.  Tags accumulate till an assembly is emitted.
+
+```GSL
+#tag color:red 
+#tag flavor:vanilla
+pTDH3>gERG10
+```
+
+Tags may be emitted in various output formats.  For example, the flatfile output emits tags using the `TA` line.
+
+```
+// GSL compiler version 0.4.32
+##### Assembly 0 #######
+A# 0
+NA basic_delete
+TA color:yellow id:123
+NP 7
+```

--- a/src/GslCore/CommonTypes.fs
+++ b/src/GslCore/CommonTypes.fs
@@ -218,7 +218,9 @@ type DnaAssembly =
     pragmas: PragmaCollection;
     designParams: DesignParams;
     docStrings: string list;
-    materializedFrom: Assembly}
+    materializedFrom: Assembly
+    tags:Set<AssemblyTag>
+    }
     with
     member x.Sequence() =
         x.dnaParts

--- a/src/GslCore/DnaCreation.fs
+++ b/src/GslCore/DnaCreation.fs
@@ -583,4 +583,6 @@ let expandAssembly
      pragmas = a.pragmas;
      designParams = a.designParams;
      docStrings = a.docStrings;
-     materializedFrom = a}
+     materializedFrom = a
+     tags=Set.empty
+     }

--- a/src/GslCore/DumpFlat.fs
+++ b/src/GslCore/DumpFlat.fs
@@ -45,6 +45,8 @@ let dumpFlat (outFile:string) (assembliesIn : DnaAssembly list) =
         sprintf "##### Assembly %s #######" aId |> w
         sprintf "A# %s" aId |> w
         sprintf "NA %s" a.name |> w
+        if not a.tags.IsEmpty then
+            sprintf "TA %s" (String.Join(" ",a.tags)) |> w
         match a.uri with Some(u) -> sprintf "NU %s" u |> w | None -> ()
         sprintf "NP %d" (a.dnaParts.Length) |> w
         sprintf "AS %s" (a.Sequence().str) |> w

--- a/src/GslCore/DumpFlat.fs
+++ b/src/GslCore/DumpFlat.fs
@@ -46,7 +46,7 @@ let dumpFlat (outFile:string) (assembliesIn : DnaAssembly list) =
         sprintf "A# %s" aId |> w
         sprintf "NA %s" a.name |> w
         if not a.tags.IsEmpty then
-            sprintf "TA %s" (String.Join(" ",a.tags)) |> w
+            sprintf "TA %s" (String.Join(" ",[for tag in a.tags -> sprintf "%s:%s" tag.nameSpace tag.tag])) |> w
         match a.uri with Some(u) -> sprintf "NU %s" u |> w | None -> ()
         sprintf "NP %d" (a.dnaParts.Length) |> w
         sprintf "AS %s" (a.Sequence().str) |> w

--- a/src/GslCore/GslCore.fsproj
+++ b/src/GslCore/GslCore.fsproj
@@ -101,6 +101,7 @@
     <Compile Include="ProcessCmdLineArgs.fs" />
     <Compile Include="LexAndParse.fs" />
     <Compile Include="AstExpansion.fs" />
+    <Compile Include="TaggingProvider.fs" />
     <Compile Include="GslcProcess.fs" />
     <Compile Include="SeamlessPlugin.fs" />
     <Compile Include="Gslc.fs" />

--- a/src/GslCore/LegacyParseTypes.fs
+++ b/src/GslCore/LegacyParseTypes.fs
@@ -67,6 +67,9 @@ type Part =
 /// Part plus a Pragma
 and PPP = { part : Part ; pr : PragmaCollection ; fwd: bool}
 
+/// Namespace bounded tag for an assembly (Used in DnaAssembly)
+type AssemblyTag = {nameSpace:string ; tag : string}
+
 type Assembly =
    {parts: PPP list; 
     name: string option;

--- a/src/GslCore/PragmaTypes.fs
+++ b/src/GslCore/PragmaTypes.fs
@@ -286,10 +286,6 @@ type Pragma = {
     args: string list}
     with
     member x.name = x.definition.name
-    member x.isTransientCumulative =
-        match x.definition.scope with
-        | BlockOnly(TransientCumulative) | BlockOrPart(TransientCumulative) -> true
-        | _ -> false
     member x.isTransient =
         match x.definition.scope with
         | BlockOnly(Persistent) | BlockOrPart(Persistent) -> false

--- a/src/GslCore/PragmaTypes.fs
+++ b/src/GslCore/PragmaTypes.fs
@@ -23,7 +23,7 @@ type PragmaArgShape =
 
 type PragmaValidationResult = Result<unit,string>
 
-type PragmaPersistence = | Persistent | Transient
+type PragmaPersistence = | Persistent | Transient | TransientCumulative
 ///<summary>
 /// Pragmas are scoped within a GSL document.  Some pragmas
 /// are somewhat "scope-polymorphic" and have different
@@ -286,6 +286,10 @@ type Pragma = {
     args: string list}
     with
     member x.name = x.definition.name
+    member x.isTransientCumulative =
+        match x.definition.scope with
+        | BlockOnly(TransientCumulative) | BlockOrPart(TransientCumulative) -> true
+        | _ -> false
     member x.isTransient =
         match x.definition.scope with
         | BlockOnly(Persistent) | BlockOrPart(Persistent) -> false
@@ -423,7 +427,22 @@ type PragmaCollection = PragmaCollection of Map<string,Pragma>
     with
     member x.pmap = match x with PragmaCollection(pc) -> pc
     /// Add a Pragma to this collection.
-    member x.Add(p:Pragma) = PragmaCollection (x.pmap.Add(p.name, p))
+    member x.Add(p:Pragma) = 
+        PragmaCollection (
+            match p.definition.scope with 
+            | BlockOnly(TransientCumulative) 
+            | BlockOrPart(TransientCumulative) ->
+                match x.pmap.TryFind(p.name) with
+                | None -> x.pmap.Add(p.name, p)
+                | Some(existing) -> 
+                    let newArgs = existing.args@p.args // new args go on the end
+                    match buildPragmaFromDef existing.definition  newArgs with
+                    | Ok (newPragma,_messages) ->
+                        x.pmap.Add(p.name, newPragma)
+                    | Bad messages -> failwithf "%s" (String.Join(";",messages))
+            | _ -> 
+                x.pmap.Add(p.name, p)
+        )
     /// Add a pragma to this collection using string name.
     member x.Add(pName:string) = x.Add(pName, [])
     /// Add a pragma to this collection using string name and single value.

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -42,13 +42,13 @@ let tagPragmaDef =
      invertsTo = None; validate = validateTag} 
 
 /// Take previous #tag namespace:tagvalue  lines and fold into the assembly structure
-let foldInTags (_at:ATContext) (a:DnaAssembly) =
+let foldInTags (cmdlineTags:AssemblyTag list) (_at:ATContext) (a:DnaAssembly) =
     match a.pragmas.TryFind("tag") with
     | None -> ok a
     | Some pragma ->
         match parseTags pragma.args with
         | Ok(newTags,_) ->
-            ok {a with tags = newTags |> List.fold (fun tags tag -> tags.Add(tag)) a.tags}
+            ok {a with tags = cmdlineTags@newTags |> List.fold (fun tags tag -> tags.Add(tag)) a.tags}
         | Bad msg -> fail {msg = String.Join(";",msg) ; kind = ATError ; assembly = a ; stackTrace = None ; fromException = None}
         
 type TaggingProvider = {
@@ -74,7 +74,7 @@ type TaggingProvider = {
         member x.ConfigureFromOptions(_opts) =
             x :> IAssemblyTransform
         member x.TransformAssembly context assembly =
-            foldInTags context assembly
+            foldInTags x.cmdlineTags context assembly
 
 /// Produce an instance of the seamless assembly plugin with the provided extra argument processor.
 let createTaggingPlugin extraArgProcessor =

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -1,0 +1,90 @@
+﻿/// Assembly transforming plugin that implements seamless part assembly.
+module TaggingPlugin
+
+open System
+open LegacyParseTypes
+open commonTypes
+open commandConfig
+open pragmaTypes
+open PluginTypes
+open Amyris.ErrorHandling
+
+let taggingArg = 
+   {name = "tag";
+    param = ["namespace:value"];
+    alias = [];
+    desc = "Add default tag to every assembly."
+   }
+
+let parseTag (single:string) state =
+    match single.IndexOf(":") with
+        | -1 -> fail (sprintf "--tag value %s missing expected colon" single)
+        | colonPosition ->
+            ok  ({  nameSpace=single.[..colonPosition-1].Trim()
+                    tag=single.[colonPosition+1..].Trim()
+                }::state)
+
+let parseTags (args:string list) =
+    args |> 
+        List.fold (
+            fun (state:Result<_,_>) (arg:string) -> 
+                state >>= (parseTag arg)
+        ) (ok [])
+
+/// do a trial parse and return ok unit if successful
+let validateTag args =
+    parseTags args 
+    >>= (fun _ -> ok ())
+
+let tagPragmaDef =
+    {name = "tag"; argShape = AtLeast 1; scope = BlockOnly(Transient);
+     desc = "tag assemblies with terms from a namespace.";
+     invertsTo = None; validate = validateTag} 
+
+/// Take previous #tag namespace:tagvalue  lines and fold into the assembly structure
+let foldInTags (_at:ATContext) (a:DnaAssembly) =
+    match a.pragmas.TryFind("tag") with
+    | None -> ok a
+    | Some pragma ->
+        match parseTags pragma.args with
+        | Ok(newTags,_) ->
+            ok {a with tags = newTags |> List.fold (fun tags tag -> tags.Add(tag)) a.tags}
+        | Bad msg -> fail {msg = String.Join(";",msg) ; kind = ATError ; assembly = a ; stackTrace = None ; fromException = None}
+        
+type TaggingProvider = {
+    cmdlineTags:AssemblyTag list
+    /// Optionally attach a function to this plugin behavior to permit its operation to be
+    /// configured by command line arguments injected by other plugins.  This is necessary because
+    /// seamless assembly can alter a lot of expectations of downstream processing steps.
+    processExtraArgs: ParsedCmdLineArg -> TaggingProvider -> TaggingProvider}
+    with
+    interface IAssemblyTransform with
+        member __.ProvidedArgs() = [taggingArg]
+        member x.Configure(arg) =
+            if arg.spec = taggingArg then
+                match parseTags arg.values with
+                | Ok(v,_) ->
+                    {x with cmdlineTags = v@x.cmdlineTags}
+                | Result.Bad messages ->
+                    failwithf "%s" (String.Join("; ",messages))
+
+            else x
+            |> x.processExtraArgs arg
+            :> IAssemblyTransform
+        member x.ConfigureFromOptions(_opts) =
+            x :> IAssemblyTransform
+        member x.TransformAssembly context assembly =
+            foldInTags context assembly
+
+/// Produce an instance of the seamless assembly plugin with the provided extra argument processor.
+let createTaggingPlugin extraArgProcessor =
+   {name = "assembly tagging support"
+    description = Some "Allow tagging of assemblies with #tag namespace:tag"
+    behaviors =
+      [{name = None;
+        description = None;
+        behavior = AssemblyTransform({cmdlineTags = []; processExtraArgs = extraArgProcessor})}]
+    providesPragmas = [tagPragmaDef];
+    providesCapas = []}
+
+let taggingPlugin = createTaggingPlugin (fun _ x -> x)

--- a/src/GslCore/TaggingProvider.fs
+++ b/src/GslCore/TaggingProvider.fs
@@ -37,7 +37,7 @@ let validateTag args =
     >>= (fun _ -> ok ())
 
 let tagPragmaDef =
-    {name = "tag"; argShape = AtLeast 1; scope = BlockOnly(Transient);
+    {name = "tag"; argShape = AtLeast 1; scope = BlockOnly(TransientCumulative);
      desc = "tag assemblies with terms from a namespace.";
      invertsTo = None; validate = validateTag} 
 

--- a/tests/GslCore.Tests/GslCore.Tests.fsproj
+++ b/tests/GslCore.Tests/GslCore.Tests.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="TestSliceAnnotations.fs" />
     <Compile Include="TestSeamlessPrimers.fs" />
     <Compile Include="TestDnaAssemblyTransformation.fs" />
+    <Compile Include="TestTagging.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/tests/GslCore.Tests/TestDnaAssemblyTransformation.fs
+++ b/tests/GslCore.Tests/TestDnaAssemblyTransformation.fs
@@ -61,6 +61,7 @@ type Test() =
         designParams = DesignParams.initialDesignParams
         docStrings = []
         materializedFrom = emptyAssembly
+        tags = Set.empty
     }
 
     let runTest assembly expectedSource =

--- a/tests/GslCore.Tests/TestTagging.fs
+++ b/tests/GslCore.Tests/TestTagging.fs
@@ -75,6 +75,18 @@ uADH1; dADH1
 uADH1; dADH1
 """ 
 
+    /// Three tags on same construct on different lines then single on next construct
+    let mixedTags = """#refgenome cenpk
+#platform stitch
+
+#tag flavor:vanilla
+#tag temp:hot
+#tag condiment:ketchup
+uADH1; dADH1
+
+#tag id:1234
+uADH2; dADH2
+""" 
     let runAndExtractTags code =
             code
             |> compileOne
@@ -153,7 +165,6 @@ uADH1; dADH1
             match pragmas1 with
             | [p] ->
                 // should match the entered text - with both pragmas together
-                printfn "YYY=%A" p
                 Assert.AreEqual(["flavor:vanilla";"temp:hot"],p.args)
 
             | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
@@ -171,12 +182,38 @@ uADH1; dADH1
 
         match results with
         | [_assembly1,pragmas1 ] ->
-            // should be two pragmas on this assembly
+            // should be one pragma on this assembly with two parts
             match pragmas1 with
             | [p] ->
-                // should match the two pragmas but combined
-                printfn "XXX=%A" p
-                Assert.IsTrue(p.hasVal "flavor:vanilla temp:hot")
+                // should match the entered text - with both pragmas together
+                Assert.AreEqual(["flavor:vanilla";"temp:hot"],p.args)
+
+            | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
+
+        | x -> failwithf "bad assembly pattern %A in TwoParallelTags" x
+
+    [<Test>]
+    member __.MixedTags() =
+        let results = mixedTags |> runAndExtractTags
+
+        // should be two assemblies
+        Assert.AreEqual(2,results.Length)
+
+        match results with
+        | [_assembly1,pragmas1 ; _assembly2,pragmas2] ->
+            // should be one pragma on assembly1 with 3 parts
+            match pragmas1 with
+            | [p] ->
+                // should match the entered text - with both pragmas together
+                Assert.AreEqual(["flavor:vanilla";"temp:hot" ; "condiment:ketchup"],p.args)
+
+            | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
+
+            // should be one pragma on assembly2 with 1 part
+            match pragmas2 with
+            | [p] ->
+                // should match the entered text - with both pragmas together
+                Assert.AreEqual(["id:1234"],p.args)
 
             | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
 

--- a/tests/GslCore.Tests/TestTagging.fs
+++ b/tests/GslCore.Tests/TestTagging.fs
@@ -1,0 +1,183 @@
+﻿namespace gslc.Tests
+open System
+open NUnit.Framework
+open Amyris.ErrorHandling
+open AstTypes
+open AstAssertions
+open AstExpansion
+open constants
+
+[<TestFixture>]
+type TestTagging() = 
+
+    /// Grab high level part wrappers around assemblies so we can see pragmas
+    let rec extractParts (n:AstNode) : ParsePart list =
+        [
+            match n with
+            | Block b -> 
+                let result = b.x |> List.collect extractParts
+                yield! result
+            | Part p -> 
+                yield p.x
+            | Splice s -> 
+                let result = s |> List.ofArray |> List.collect extractParts
+                yield! result
+            | _ -> ()
+        ]
+
+    /// compile one GSL source example and extract assemblies
+    let compileOne source =
+        source 
+        |> GslSourceCode
+        |> compile (phase1 Set.empty) 
+        |> returnOrFail
+        |> fun x -> extractParts x.wrappedNode
+
+    /// example with no #tag
+    let noTag = """#refgenome cenpk
+#platform stitch
+
+uADH1; dADH1
+""" 
+
+    /// one tag on a construct
+    let simpleTag = """#refgenome cenpk
+#platform stitch
+
+#tag flavor:vanilla
+uADH1; dADH1
+""" 
+
+    /// two tags on two different constructs
+    let twoSerialTags = """#refgenome cenpk
+#platform stitch
+
+#tag flavor:vanilla
+uADH1; dADH1
+#tag temp:hot
+uADH2; dADH2
+""" 
+
+    /// two tags on same line of tag
+    let twoTandemTags = """#refgenome cenpk
+#platform stitch
+
+#tag flavor:vanilla temp:hot
+uADH1; dADH1
+""" 
+
+    /// two tags on same construct on different lines
+    let twoParallelTags = """#refgenome cenpk
+#platform stitch
+
+#tag flavor:vanilla
+#tag temp:hot
+uADH1; dADH1
+""" 
+
+    let runAndExtractTags code =
+            code
+            |> compileOne
+            |> List.map (fun p ->
+                            let tagPragmas =
+                                p.pragmas 
+                                |> List.choose (fun n ->
+                                    match n with
+                                    | Pragma(p) when p.x.name = "tag" ->
+                                        Some p.x
+                                    | _ -> 
+                                        None
+                                )
+                            p,tagPragmas
+                        )
+
+    do
+        // initialize pragmas
+        pragmaTypes.finalizePragmas [TaggingPlugin.tagPragmaDef]
+
+    [<Test>]
+    member __.TestNoTag() =
+
+        let results = noTag |> runAndExtractTags
+
+        // should be one assembly
+        Assert.AreEqual(1,results.Length)
+
+        let _assembly,pragmas = results.Head
+        // should be zero pragmas
+        Assert.AreEqual(0,pragmas.Length)
+
+    [<Test>]
+    member __.TestSimpleTag() =
+
+        let results = simpleTag |> runAndExtractTags
+
+        // should be one assembly
+        Assert.AreEqual(1,results.Length)
+
+        let _assembly,pragmas = results.Head
+        // should just be one pragma
+        Assert.AreEqual(1,pragmas.Length)
+        // should match the entered text
+        Assert.IsTrue(pragmas.Head.hasVal "flavor:vanilla")
+
+    [<Test>]
+    member __.TwoSerialTags() =
+
+        let results = twoSerialTags |> runAndExtractTags
+
+        // should be two assemblies
+        Assert.AreEqual(2,results.Length)
+
+        match results with
+        | [_assembly1,pragmas1 ; _assembly2,pragmas2] ->
+            // should just be one pragma on each
+            Assert.AreEqual(1,pragmas1.Length)
+            Assert.AreEqual(1,pragmas2.Length)
+            // should match the entered text
+            Assert.IsTrue(pragmas1.Head.hasVal "flavor:vanilla")
+            Assert.IsTrue(pragmas2.Head.hasVal "temp:hot")
+        | x -> failwithf "bad config %A in TwoSerialTags" x
+
+    [<Test>]
+    member __.TwoTandemTags() =
+
+        let results = twoTandemTags |> runAndExtractTags
+
+        // should be one assemby
+        Assert.AreEqual(1,results.Length)
+
+        match results with
+        | [_assembly1,pragmas1 ] ->
+            // should be two pragmas on this assembly
+            match pragmas1 with
+            | [p] ->
+                // should match the entered text - with both pragmas together
+                printfn "YYY=%A" p
+                Assert.AreEqual(["flavor:vanilla";"temp:hot"],p.args)
+
+            | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
+
+        | x -> failwithf "bad assembly pattern %A in TwoParallelTags" x
+
+    [<Test>]
+    member __.TwoParallelTags() =
+        // two tags created on different lines
+
+        let results = twoParallelTags |> runAndExtractTags
+
+        // should be one assemby
+        Assert.AreEqual(1,results.Length)
+
+        match results with
+        | [_assembly1,pragmas1 ] ->
+            // should be two pragmas on this assembly
+            match pragmas1 with
+            | [p] ->
+                // should match the two pragmas but combined
+                printfn "XXX=%A" p
+                Assert.IsTrue(p.hasVal "flavor:vanilla temp:hot")
+
+            | x -> failwithf "unexpected number of pragmas %d:\n%A" x.Length x
+
+        | x -> failwithf "bad assembly pattern %A in TwoParallelTags" x


### PR DESCRIPTION
Hopefully this one is a little simpler than last PR.  This adds the `#tag namespace:tag` feature and extends pragma semantics to add a transient cumulative option.