### PR TITLE
BUG/FEA: relying  on defaultRefGenome gives empty dnaSource field

### DIFF
--- a/src/GslCore/DnaCreation.fs
+++ b/src/GslCore/DnaCreation.fs
@@ -261,13 +261,20 @@ let expandGenePart
     (rgs:GenomeDefs)
     (library: SequenceLibrary)
     (a:Assembly)
-    dnaSource
+    specifiedDnaSource
     (ppp:PPP)
     (gp:GenePartWithLinker) =
 
     match gp.linker with
     | None -> () // No linkers were present
     | Some(l) -> checkLinker l // Test the linkers
+
+    // If the dna source is empty, then we are going to pull the DNA
+    // part from the default reference genome, so we should make the
+    // dnaSource field reflect this
+    let dnaSource = 
+        if specifiedDnaSource = "" then defaultRefGenome
+        else specifiedDnaSource
 
     // Check the genes are legal
     //let prefix = gp.part.gene.[0]


### PR DESCRIPTION
The compiler has logic for parts like pGAL1 that enables it to retrieve a cenpk part using the defaultRefGenome field when the user specifies no reference genome.  In this case, the dnaSource field is left as an empty string which makes recovering true DNA source difficult for downstream build applications.  This small patch ensures the dnaSource reflects the reliance on that default field when the proposed field would be ""