### PR TITLE
remove deprecated inline linker syntax

### DIFF
--- a/src/GslCore/AstAlgorithms.fs
+++ b/src/GslCore/AstAlgorithms.fs
@@ -94,11 +94,7 @@ let decompile tree =
         | InlineDna({x=dna; positions=_}) -> appendf "/%s/" dna
         | InlineProtein({x=pseq; positions=_}) -> appendf "/$%s/" pseq
         | HetBlock(_) -> append "~"
-        | Gene({x=pg; positions=_}) ->
-            match pg.linker with
-            | Some({l1=l1; l2=l2; orient=o}) ->
-                append (sprintf "%s-%s-%s-%s" l1 l2 o pg.gene)
-            | None -> append pg.gene
+        | Gene({x=gene; positions=_}) -> append gene
         // part mods
         | ParseRelPos({x=rp; positions=_}) ->
             _print rp.i state

--- a/src/GslCore/AstExpansion.fs
+++ b/src/GslCore/AstExpansion.fs
@@ -461,13 +461,13 @@ let private expandMut
             // Does it contain a mutation modification?
             // Make sure we have only one if so.
             // TODO: this restriction may not be necessary
-            match gp.part.mods |> List.choose modIsMutation with
+            match gp.mods |> List.choose modIsMutation with
             | [] -> p
             | [mutMod] ->
-                if (not (gp.part.gene.[0] = 'G' || gp.part.gene.[0] = 'g')) then
+                if (not (gp.gene.[0] = 'G' || gp.gene.[0] = 'g')) then
                     failwithf
                         "Allele swap gene must be g-type  e.g gABC1$x1234y.  '%c' is not a legal prefix for %s"
-                        (gp.part.gene.[0]) gp.part.gene
+                        (gp.gene.[0]) gp.gene
                 let rg' = getRG a rgs p.pr
 
                 // FIXME: unclear if this was the right behavior, as the rg is selected from both
@@ -492,9 +492,9 @@ let private expandMut
                          | CTERM -> "Cterm"
                          | NONETERM -> "No end preference")
 
-                if not (rg'.IsValid(gp.part.gene.[1..])) then
+                if not (rg'.IsValid(gp.gene.[1..])) then
                     failwithf "Undefined gene '%s' %O\n"
-                        (gp.part.gene.[1..]) (gp.part.where)
+                        (gp.gene.[1..]) (gp.where)
 
                 let asAACheck =
                     match a.pragmas.TryFind("warnoff") with
@@ -520,7 +520,7 @@ let private expandMut
                         verbose
                         rg'
                         codonUsage
-                        gp.part.gene
+                        gp.gene
                         mutMod
                         endPref
                         a.capabilities
@@ -724,10 +724,10 @@ let private expandHB
             // but that's embedded down in the mod list
 
             // Assume they must be using a gene part next to a het block.  Bad?
-            if (not (gp.part.gene.StartsWith("g"))) then
-                failwithf "Heterology block must be adjacent to g part, %s not allowed" gp.part.gene
+            if (not (gp.gene.StartsWith("g"))) then
+                failwithf "Heterology block must be adjacent to g part, %s not allowed" gp.gene
             let s = translateGenePrefix a.pragmas rg' GENE // Start with standard slice
-            let startSlice = applySlices verbose gp.part.mods s // Apply modifiers
+            let startSlice = applySlices verbose gp.mods s // Apply modifiers
             let newSlice =
                 {startSlice with
                     left =
@@ -739,12 +739,12 @@ let private expandHB
             // putting in new consolidated slice.
             let newMods =
                 SLICE(newSlice)
-                ::(gp.part.mods |> List.filter modIsNotSlice)
+                ::(gp.mods |> List.filter modIsNotSlice)
 
             // Prepend backwards as we will flip list at end - watch out, pragmas are reversed as well
             scan
                 a
-                ((GENEPART({gp with part = {gp.part with mods = newMods}}),pr3,fwd3)
+                ((GENEPART({gp with mods = newMods}),pr3,fwd3)
                  ::(INLINEDNA(alt), returnOrFail (pr2.Add("inline")), fwd2)
                  ::(GENEPART(gpUp),pr1,fwd1)
                  ::res)
@@ -778,13 +778,13 @@ let private expandHB
             // but that's embedded down in the mod list
 
             // Assume they must be using a gene part next to a het block.  Bad?
-            if not (gp.part.gene.[0] = 'g') then
+            if not (gp.gene.[0] = 'g') then
                 failwithf
                     "Slices adjacent to het block elements ~ must be gene slices - %s has '%c' gene part"
-                    gp.part.gene gp.part.gene.[0]
+                    gp.gene gp.gene.[0]
 
             let s = translateGenePrefix a.pragmas rg'' GENE // Start with standard slice
-            let startSlice = applySlices verbose gp.part.mods s // Apply modifiers
+            let startSlice = applySlices verbose gp.mods s // Apply modifiers
             let newSlice =
                 {startSlice with
                     left =
@@ -796,12 +796,12 @@ let private expandHB
             // Assemble new mod list by getting rid of existing slice mods and putting in new consolidated slice.
             let newMods =
                 SLICE(newSlice)
-                ::(gp.part.mods |> List.filter modIsNotSlice)
+                ::(gp.mods |> List.filter modIsNotSlice)
             // Prepend backwards as we will flip list at end
             // Note - currently destroy any pragmas attached to the heterology block itself
             scan
                 a
-                ((GENEPART({ gp with part = {gp.part with mods = newMods}} ),pr4,fwd4)
+                ((GENEPART({gp with mods = newMods}), pr4, fwd4)
                  ::(INLINEDNA(newInline), returnOrFail (pr2.Add("inline")),fwd2)
                  ::(GENEPART(gpUp),pr1,fwd1)
                  ::res)
@@ -831,11 +831,11 @@ let private expandHB
             // but that's embedded down in the mod list
 
             // Assume they must be using a gene part next to a het block.  Bad?
-            assert(gp.part.gene.[0] = 'g')
+            assert(gp.gene.[0] = 'g')
 
             // now build up the slice again and apply from scratch to the gene
             let s = translateGenePrefix a.pragmas rg' GENE // Start with standard slice
-            let startSlice = applySlices verbose gp.part.mods s // Apply modifiers
+            let startSlice = applySlices verbose gp.mods s // Apply modifiers
 
             // modify slice to take into account the bit we chopped off
             let newSlice =
@@ -860,14 +860,14 @@ let private expandHB
             // putting in new consolidated slice.
             let newMods =
                 SLICE(newSlice)
-                ::(gp.part.mods |> List.filter modIsNotSlice)
+                ::(gp.mods |> List.filter modIsNotSlice)
             // Prepend backwards as we will flip list at end
             // Note - currently destroy pr2 pragmas associated with the hetblock
             scan
                 a
                 ((GENEPART(gpDown),pr4,fwd4)
                  ::(INLINEDNA(newInline), returnOrFail (pr3.Add("inline")),fwd3)
-                 ::(GENEPART({gp with part = {gp.part with mods = newMods}}),pr1,fwd1)
+                 ::(GENEPART({gp with mods = newMods}), pr1, fwd1)
                  ::res)
                 tl
 

--- a/src/GslCore/AstProcess.fs
+++ b/src/GslCore/AstProcess.fs
@@ -810,7 +810,7 @@ let updateDocstringEnvironment = pretransformOnly updateDocstringEnvironmentInne
 let private checkGeneName (rgs:GenomeDefs) (library: Map<string, Dna>) assemblyPragmas node =
     match node with
     | GenePart(pp, gp) ->
-        let geneName = gp.x.gene.[1..].ToUpper()
+        let geneName = gp.x.[1..].ToUpper()
         let partPragmas = getPragmas pp
         getRGNew rgs [partPragmas; assemblyPragmas]
         |> mapMessages (fun s -> errorMessage RefGenomeError s node)

--- a/src/GslCore/AstTypes.fs
+++ b/src/GslCore/AstTypes.fs
@@ -141,8 +141,6 @@ type Mutation = {f:char; t:char; loc:int; mType:MType}
 
 type Linker = {l1:string; l2:string; orient:string}
 
-type ParseGene = {gene: string; linker:Linker option}
-
 /// Supported binary operations on nodes.
 type BinaryOperator = | Add | Subtract | Multiply | Divide
 
@@ -201,7 +199,7 @@ and AstNode =
     | InlineDna of Node<string>
     | InlineProtein of Node<string>
     | HetBlock of Node<unit>
-    | Gene of Node<ParseGene>
+    | Gene of Node<string>
     | Assembly of Node<AstNode list>
     // AST nodes for Level 2 syntax support
     | L2Id of Node<L2Id>
@@ -613,11 +611,6 @@ let createPart mods pragmas basePart =
 
 /// Create a top-level part with empty collections and default values from a base part.
 let createPartWithBase = createPart [] []
-
-/// Create a top-level part given a gene ID.
-let createGenePart (gene: PString) (linker: Linker option) =
-    // The base part for this part will be a Gene AST node.
-    createPartWithBase (Gene({x = {gene = gene.i; linker = linker}; positions = [gene.pos]}))
 
 /// Capture a list of parsed mods and stuff them into their associated part.
 let stuffModsIntoPart astPart mods =

--- a/src/GslCore/Constants.fs
+++ b/src/GslCore/Constants.fs
@@ -31,11 +31,6 @@ let defaultRefGenome = "cenpk"
 
 let aaLegal = "ACDEFGHIKLMNPQRSTVWY*" |> Set.ofSeq
 
-/// List of approved linker abbreviations.
-let legalLinkers =
-    [ '0' .. '9' ] @ [ 'A'..'E']
-    |> List.map (fun c -> sprintf "%c" c) |> Set.ofSeq
-
 [<Measure>] type OneOffset
 [<Measure>] type ZeroOffset
 

--- a/src/GslCore/GslParser.fs
+++ b/src/GslCore/GslParser.fs
@@ -141,7 +141,6 @@ type nonTerminalId =
     | NONTERM_FloatLiteral
     | NONTERM_StringLiteral
     | NONTERM_IntExp
-    | NONTERM_Linker
     | NONTERM_Part
     | NONTERM_PartMaybeMods
     | NONTERM_PartMaybePragma
@@ -337,7 +336,7 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 55 -> NONTERM_IntExp 
     | 56 -> NONTERM_IntExp 
     | 57 -> NONTERM_IntExp 
-    | 58 -> NONTERM_Linker 
+    | 58 -> NONTERM_Part 
     | 59 -> NONTERM_Part 
     | 60 -> NONTERM_Part 
     | 61 -> NONTERM_Part 
@@ -347,65 +346,63 @@ let prodIdxToNonTerminal (prodIdx:int) =
     | 65 -> NONTERM_Part 
     | 66 -> NONTERM_Part 
     | 67 -> NONTERM_Part 
-    | 68 -> NONTERM_Part 
-    | 69 -> NONTERM_Part 
-    | 70 -> NONTERM_PartMaybeMods 
-    | 71 -> NONTERM_PartMaybeMods 
-    | 72 -> NONTERM_PartMaybePragma 
-    | 73 -> NONTERM_PartMaybePragma 
-    | 74 -> NONTERM_PartFwdRev 
-    | 75 -> NONTERM_PartFwdRev 
-    | 76 -> NONTERM_CompletePart 
-    | 77 -> NONTERM_RelPos 
-    | 78 -> NONTERM_RelPos 
+    | 68 -> NONTERM_PartMaybeMods 
+    | 69 -> NONTERM_PartMaybeMods 
+    | 70 -> NONTERM_PartMaybePragma 
+    | 71 -> NONTERM_PartMaybePragma 
+    | 72 -> NONTERM_PartFwdRev 
+    | 73 -> NONTERM_PartFwdRev 
+    | 74 -> NONTERM_CompletePart 
+    | 75 -> NONTERM_RelPos 
+    | 76 -> NONTERM_RelPos 
+    | 77 -> NONTERM_Slice 
+    | 78 -> NONTERM_Slice 
     | 79 -> NONTERM_Slice 
     | 80 -> NONTERM_Slice 
-    | 81 -> NONTERM_Slice 
-    | 82 -> NONTERM_Slice 
+    | 81 -> NONTERM_Mod 
+    | 82 -> NONTERM_Mod 
     | 83 -> NONTERM_Mod 
     | 84 -> NONTERM_Mod 
-    | 85 -> NONTERM_Mod 
-    | 86 -> NONTERM_Mod 
-    | 87 -> NONTERM_ModList 
-    | 88 -> NONTERM_ModList 
-    | 89 -> NONTERM_PartList 
-    | 90 -> NONTERM_PartList 
-    | 91 -> NONTERM_AssemblyPart 
-    | 92 -> NONTERM_L2IdWrap 
-    | 93 -> NONTERM_L2IdWrap 
-    | 94 -> NONTERM_L2Id 
-    | 95 -> NONTERM_L2Id 
+    | 85 -> NONTERM_ModList 
+    | 86 -> NONTERM_ModList 
+    | 87 -> NONTERM_PartList 
+    | 88 -> NONTERM_PartList 
+    | 89 -> NONTERM_AssemblyPart 
+    | 90 -> NONTERM_L2IdWrap 
+    | 91 -> NONTERM_L2IdWrap 
+    | 92 -> NONTERM_L2Id 
+    | 93 -> NONTERM_L2Id 
+    | 94 -> NONTERM_L2Promoter 
+    | 95 -> NONTERM_L2Promoter 
     | 96 -> NONTERM_L2Promoter 
     | 97 -> NONTERM_L2Promoter 
-    | 98 -> NONTERM_L2Promoter 
-    | 99 -> NONTERM_L2Promoter 
-    | 100 -> NONTERM_L2Locus 
-    | 101 -> NONTERM_L2ExpElement 
-    | 102 -> NONTERM_L2ExpElementList 
-    | 103 -> NONTERM_L2ExpElementList 
+    | 98 -> NONTERM_L2Locus 
+    | 99 -> NONTERM_L2ExpElement 
+    | 100 -> NONTERM_L2ExpElementList 
+    | 101 -> NONTERM_L2ExpElementList 
+    | 102 -> NONTERM_L2ExpLine 
+    | 103 -> NONTERM_L2ExpLine 
     | 104 -> NONTERM_L2ExpLine 
-    | 105 -> NONTERM_L2ExpLine 
-    | 106 -> NONTERM_L2ExpLine 
-    | 107 -> NONTERM_RID 
-    | 108 -> NONTERM_RID 
-    | 109 -> NONTERM_RoughageMarker 
-    | 110 -> NONTERM_RoughageMarkerMaybe 
-    | 111 -> NONTERM_RoughageMarkerMaybe 
-    | 112 -> NONTERM_RoughagePartFwd 
-    | 113 -> NONTERM_RoughagePartRev 
-    | 114 -> NONTERM_RoughageElement 
-    | 115 -> NONTERM_RoughageElement 
-    | 116 -> NONTERM_RoughageElementList 
-    | 117 -> NONTERM_RoughageElementList 
-    | 118 -> NONTERM_RoughageLocus 
-    | 119 -> NONTERM_RoughageLocus 
+    | 105 -> NONTERM_RID 
+    | 106 -> NONTERM_RID 
+    | 107 -> NONTERM_RoughageMarker 
+    | 108 -> NONTERM_RoughageMarkerMaybe 
+    | 109 -> NONTERM_RoughageMarkerMaybe 
+    | 110 -> NONTERM_RoughagePartFwd 
+    | 111 -> NONTERM_RoughagePartRev 
+    | 112 -> NONTERM_RoughageElement 
+    | 113 -> NONTERM_RoughageElement 
+    | 114 -> NONTERM_RoughageElementList 
+    | 115 -> NONTERM_RoughageElementList 
+    | 116 -> NONTERM_RoughageLocus 
+    | 117 -> NONTERM_RoughageLocus 
+    | 118 -> NONTERM_RoughageLine 
+    | 119 -> NONTERM_RoughageLine 
     | 120 -> NONTERM_RoughageLine 
-    | 121 -> NONTERM_RoughageLine 
-    | 122 -> NONTERM_RoughageLine 
+    | 121 -> NONTERM_RoughageLineList 
+    | 122 -> NONTERM_RoughageLineList 
     | 123 -> NONTERM_RoughageLineList 
     | 124 -> NONTERM_RoughageLineList 
-    | 125 -> NONTERM_RoughageLineList 
-    | 126 -> NONTERM_RoughageLineList 
     | _ -> failwith "prodIdxToNonTerminal: bad production index"
 
 let _fsyacc_endOfInputTag = 49 
@@ -512,18 +509,18 @@ let _fsyacc_dataOfToken (t:token) =
   | STRING _fsyacc_x -> Microsoft.FSharp.Core.Operators.box _fsyacc_x 
   | INT _fsyacc_x -> Microsoft.FSharp.Core.Operators.box _fsyacc_x 
   | ID _fsyacc_x -> Microsoft.FSharp.Core.Operators.box _fsyacc_x 
-let _fsyacc_gotos = [| 0us; 65535us; 1us; 65535us; 0us; 1us; 1us; 65535us; 0us; 2us; 5us; 65535us; 0us; 22us; 6us; 22us; 9us; 22us; 56us; 22us; 60us; 22us; 5us; 65535us; 0us; 3us; 6us; 7us; 9us; 10us; 56us; 57us; 60us; 61us; 5us; 65535us; 0us; 9us; 6us; 9us; 9us; 9us; 56us; 9us; 60us; 9us; 2us; 65535us; 25us; 25us; 27us; 25us; 2us; 65535us; 25us; 26us; 27us; 28us; 7us; 65535us; 0us; 18us; 6us; 18us; 9us; 18us; 29us; 29us; 31us; 29us; 56us; 18us; 60us; 18us; 2us; 65535us; 29us; 30us; 31us; 32us; 2us; 65535us; 33us; 34us; 126us; 127us; 5us; 65535us; 0us; 19us; 6us; 19us; 9us; 19us; 56us; 19us; 60us; 19us; 2us; 65535us; 51us; 52us; 53us; 54us; 5us; 65535us; 0us; 21us; 6us; 21us; 9us; 21us; 56us; 21us; 60us; 21us; 2us; 65535us; 70us; 69us; 73us; 69us; 2us; 65535us; 70us; 71us; 73us; 74us; 5us; 65535us; 0us; 20us; 6us; 20us; 9us; 20us; 56us; 20us; 60us; 20us; 16us; 65535us; 37us; 82us; 70us; 82us; 73us; 82us; 85us; 82us; 86us; 82us; 89us; 82us; 96us; 82us; 97us; 82us; 98us; 82us; 99us; 82us; 133us; 82us; 135us; 82us; 138us; 82us; 140us; 82us; 143us; 82us; 146us; 82us; 3us; 65535us; 37us; 44us; 70us; 66us; 73us; 66us; 3us; 65535us; 37us; 42us; 70us; 65us; 73us; 65us; 16us; 65535us; 37us; 40us; 70us; 64us; 73us; 64us; 85us; 87us; 86us; 87us; 89us; 90us; 96us; 91us; 97us; 92us; 98us; 93us; 99us; 94us; 133us; 95us; 135us; 95us; 138us; 95us; 140us; 95us; 143us; 95us; 146us; 95us; 14us; 65535us; 0us; 104us; 6us; 104us; 9us; 104us; 37us; 104us; 56us; 104us; 60us; 104us; 70us; 104us; 73us; 104us; 86us; 104us; 101us; 104us; 129us; 104us; 158us; 104us; 179us; 104us; 182us; 104us; 14us; 65535us; 0us; 124us; 6us; 124us; 9us; 124us; 37us; 124us; 56us; 124us; 60us; 124us; 70us; 124us; 73us; 124us; 86us; 124us; 101us; 124us; 129us; 124us; 158us; 124us; 179us; 124us; 182us; 124us; 14us; 65535us; 0us; 126us; 6us; 126us; 9us; 126us; 37us; 126us; 56us; 126us; 60us; 126us; 70us; 126us; 73us; 126us; 86us; 126us; 101us; 126us; 129us; 126us; 158us; 126us; 179us; 126us; 182us; 126us; 14us; 65535us; 0us; 128us; 6us; 128us; 9us; 128us; 37us; 128us; 56us; 128us; 60us; 128us; 70us; 128us; 73us; 128us; 86us; 128us; 101us; 128us; 129us; 130us; 158us; 128us; 179us; 128us; 182us; 128us; 13us; 65535us; 0us; 131us; 6us; 131us; 9us; 131us; 37us; 131us; 56us; 131us; 60us; 131us; 70us; 131us; 73us; 131us; 86us; 131us; 101us; 131us; 158us; 131us; 179us; 131us; 182us; 131us; 13us; 65535us; 0us; 157us; 6us; 157us; 9us; 157us; 37us; 46us; 56us; 157us; 60us; 157us; 70us; 67us; 73us; 67us; 86us; 156us; 101us; 156us; 158us; 156us; 179us; 172us; 182us; 172us; 6us; 65535us; 133us; 134us; 135us; 136us; 138us; 139us; 140us; 141us; 143us; 144us; 146us; 147us; 2us; 65535us; 124us; 151us; 125us; 151us; 2us; 65535us; 124us; 154us; 125us; 155us; 1us; 65535us; 124us; 125us; 11us; 65535us; 0us; 160us; 6us; 160us; 9us; 160us; 37us; 160us; 56us; 160us; 60us; 160us; 70us; 160us; 73us; 160us; 86us; 160us; 101us; 160us; 158us; 159us; 10us; 65535us; 0us; 12us; 6us; 12us; 9us; 12us; 37us; 48us; 56us; 12us; 60us; 12us; 70us; 68us; 73us; 68us; 86us; 102us; 101us; 102us; 7us; 65535us; 0us; 164us; 6us; 164us; 9us; 164us; 56us; 164us; 60us; 164us; 165us; 166us; 176us; 164us; 6us; 65535us; 0us; 173us; 6us; 173us; 9us; 173us; 56us; 173us; 60us; 173us; 176us; 177us; 7us; 65535us; 0us; 175us; 6us; 175us; 9us; 175us; 56us; 175us; 60us; 175us; 179us; 175us; 182us; 175us; 5us; 65535us; 0us; 181us; 6us; 181us; 9us; 181us; 56us; 181us; 60us; 181us; 7us; 65535us; 0us; 178us; 6us; 178us; 9us; 178us; 56us; 178us; 60us; 178us; 179us; 178us; 182us; 178us; 7us; 65535us; 0us; 184us; 6us; 184us; 9us; 184us; 56us; 184us; 60us; 184us; 179us; 180us; 182us; 183us; 5us; 65535us; 0us; 14us; 6us; 14us; 9us; 14us; 56us; 14us; 60us; 14us; 8us; 65535us; 15us; 194us; 195us; 196us; 197us; 198us; 202us; 192us; 207us; 193us; 213us; 193us; 216us; 194us; 217us; 194us; 3us; 65535us; 199us; 191us; 203us; 191us; 209us; 210us; 2us; 65535us; 199us; 200us; 203us; 204us; 6us; 65535us; 15us; 199us; 202us; 203us; 207us; 199us; 213us; 199us; 216us; 199us; 217us; 199us; 5us; 65535us; 15us; 201us; 207us; 201us; 213us; 201us; 216us; 201us; 217us; 201us; 5us; 65535us; 15us; 205us; 207us; 205us; 213us; 205us; 216us; 205us; 217us; 205us; 5us; 65535us; 15us; 215us; 207us; 208us; 213us; 214us; 216us; 215us; 217us; 215us; 3us; 65535us; 15us; 211us; 216us; 211us; 217us; 211us; 3us; 65535us; 15us; 216us; 216us; 216us; 217us; 216us; 3us; 65535us; 15us; 16us; 216us; 219us; 217us; 218us; |]
-let _fsyacc_sparseGotoTableRowOffsets = [|0us; 1us; 3us; 5us; 11us; 17us; 23us; 26us; 29us; 37us; 40us; 43us; 49us; 52us; 58us; 61us; 64us; 70us; 87us; 91us; 95us; 112us; 127us; 142us; 157us; 172us; 186us; 200us; 207us; 210us; 213us; 215us; 227us; 238us; 246us; 253us; 261us; 267us; 275us; 283us; 289us; 298us; 302us; 305us; 312us; 318us; 324us; 330us; 334us; 338us; |]
-let _fsyacc_stateToProdIdxsTableElements = [| 1us; 0us; 1us; 0us; 1us; 1us; 1us; 2us; 1us; 2us; 1us; 3us; 1us; 4us; 1us; 4us; 1us; 4us; 2us; 5us; 6us; 1us; 6us; 1us; 7us; 1us; 8us; 1us; 9us; 1us; 10us; 1us; 11us; 1us; 11us; 1us; 11us; 1us; 12us; 1us; 13us; 1us; 14us; 1us; 15us; 1us; 16us; 1us; 17us; 1us; 18us; 2us; 19us; 20us; 1us; 19us; 2us; 21us; 22us; 1us; 21us; 2us; 23us; 24us; 1us; 24us; 2us; 25us; 26us; 2us; 25us; 26us; 2us; 25us; 26us; 1us; 26us; 8us; 27us; 28us; 29us; 30us; 31us; 32us; 35us; 36us; 8us; 27us; 28us; 29us; 30us; 31us; 32us; 35us; 36us; 6us; 27us; 28us; 29us; 30us; 31us; 32us; 3us; 27us; 51us; 68us; 1us; 27us; 5us; 28us; 54us; 55us; 56us; 57us; 1us; 28us; 1us; 29us; 1us; 29us; 1us; 30us; 1us; 30us; 3us; 31us; 89us; 90us; 1us; 31us; 1us; 32us; 1us; 32us; 2us; 33us; 34us; 1us; 34us; 1us; 34us; 2us; 35us; 36us; 1us; 35us; 1us; 35us; 1us; 35us; 1us; 35us; 1us; 35us; 1us; 36us; 1us; 36us; 1us; 36us; 1us; 36us; 3us; 37us; 51us; 68us; 5us; 38us; 54us; 55us; 56us; 57us; 1us; 39us; 1us; 40us; 3us; 41us; 89us; 90us; 1us; 42us; 2us; 43us; 44us; 1us; 43us; 1us; 43us; 5us; 45us; 46us; 61us; 92us; 98us; 2us; 45us; 46us; 1us; 45us; 1us; 45us; 1us; 46us; 1us; 47us; 2us; 47us; 48us; 1us; 48us; 1us; 48us; 1us; 49us; 1us; 50us; 1us; 51us; 2us; 51us; 68us; 1us; 52us; 2us; 52us; 59us; 5us; 52us; 54us; 55us; 56us; 57us; 1us; 52us; 1us; 53us; 5us; 53us; 54us; 55us; 56us; 57us; 5us; 54us; 54us; 55us; 56us; 57us; 5us; 54us; 55us; 55us; 56us; 57us; 5us; 54us; 55us; 56us; 56us; 57us; 5us; 54us; 55us; 56us; 57us; 57us; 6us; 54us; 55us; 56us; 57us; 77us; 78us; 1us; 54us; 1us; 55us; 1us; 56us; 1us; 57us; 1us; 58us; 1us; 59us; 1us; 59us; 1us; 59us; 1us; 60us; 1us; 60us; 1us; 60us; 1us; 61us; 2us; 61us; 98us; 1us; 62us; 4us; 63us; 64us; 65us; 66us; 1us; 63us; 1us; 63us; 3us; 64us; 65us; 66us; 2us; 64us; 65us; 1us; 64us; 1us; 65us; 1us; 65us; 1us; 66us; 1us; 66us; 1us; 67us; 1us; 68us; 1us; 69us; 1us; 69us; 2us; 70us; 71us; 2us; 71us; 88us; 2us; 72us; 73us; 1us; 72us; 1us; 74us; 1us; 75us; 1us; 75us; 1us; 76us; 1us; 78us; 4us; 79us; 80us; 81us; 82us; 2us; 79us; 81us; 2us; 79us; 81us; 1us; 79us; 1us; 79us; 2us; 80us; 82us; 2us; 80us; 82us; 2us; 80us; 82us; 1us; 80us; 1us; 80us; 1us; 81us; 1us; 81us; 1us; 81us; 1us; 82us; 1us; 82us; 1us; 82us; 1us; 83us; 1us; 84us; 1us; 85us; 1us; 86us; 1us; 86us; 1us; 87us; 1us; 88us; 2us; 89us; 90us; 3us; 89us; 90us; 99us; 1us; 90us; 1us; 90us; 1us; 91us; 1us; 92us; 1us; 93us; 3us; 93us; 96us; 97us; 2us; 94us; 95us; 1us; 95us; 1us; 95us; 2us; 96us; 97us; 1us; 97us; 1us; 97us; 1us; 98us; 1us; 98us; 1us; 99us; 1us; 100us; 1us; 100us; 1us; 101us; 1us; 101us; 1us; 101us; 2us; 102us; 103us; 1us; 103us; 1us; 103us; 2us; 104us; 105us; 1us; 105us; 1us; 105us; 1us; 106us; 2us; 107us; 108us; 1us; 108us; 1us; 108us; 1us; 109us; 1us; 109us; 1us; 109us; 1us; 110us; 1us; 112us; 2us; 112us; 113us; 4us; 112us; 113us; 118us; 119us; 1us; 112us; 1us; 112us; 1us; 113us; 1us; 113us; 1us; 114us; 1us; 114us; 1us; 115us; 1us; 115us; 1us; 115us; 1us; 115us; 2us; 116us; 117us; 1us; 117us; 1us; 117us; 1us; 117us; 2us; 118us; 119us; 1us; 119us; 2us; 120us; 121us; 1us; 121us; 1us; 121us; 1us; 121us; 1us; 122us; 2us; 123us; 126us; 2us; 124us; 125us; 1us; 124us; 1us; 126us; |]
-let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us; 2us; 4us; 6us; 8us; 10us; 12us; 14us; 16us; 18us; 21us; 23us; 25us; 27us; 29us; 31us; 33us; 35us; 37us; 39us; 41us; 43us; 45us; 47us; 49us; 51us; 54us; 56us; 59us; 61us; 64us; 66us; 69us; 72us; 75us; 77us; 86us; 95us; 102us; 106us; 108us; 114us; 116us; 118us; 120us; 122us; 124us; 128us; 130us; 132us; 134us; 137us; 139us; 141us; 144us; 146us; 148us; 150us; 152us; 154us; 156us; 158us; 160us; 162us; 166us; 172us; 174us; 176us; 180us; 182us; 185us; 187us; 189us; 195us; 198us; 200us; 202us; 204us; 206us; 209us; 211us; 213us; 215us; 217us; 219us; 222us; 224us; 227us; 233us; 235us; 237us; 243us; 249us; 255us; 261us; 267us; 274us; 276us; 278us; 280us; 282us; 284us; 286us; 288us; 290us; 292us; 294us; 296us; 298us; 301us; 303us; 308us; 310us; 312us; 316us; 319us; 321us; 323us; 325us; 327us; 329us; 331us; 333us; 335us; 337us; 340us; 343us; 346us; 348us; 350us; 352us; 354us; 356us; 358us; 363us; 366us; 369us; 371us; 373us; 376us; 379us; 382us; 384us; 386us; 388us; 390us; 392us; 394us; 396us; 398us; 400us; 402us; 404us; 406us; 408us; 410us; 412us; 415us; 419us; 421us; 423us; 425us; 427us; 429us; 433us; 436us; 438us; 440us; 443us; 445us; 447us; 449us; 451us; 453us; 455us; 457us; 459us; 461us; 463us; 466us; 468us; 470us; 473us; 475us; 477us; 479us; 482us; 484us; 486us; 488us; 490us; 492us; 494us; 496us; 499us; 504us; 506us; 508us; 510us; 512us; 514us; 516us; 518us; 520us; 522us; 524us; 527us; 529us; 531us; 533us; 536us; 538us; 541us; 543us; 545us; 547us; 549us; 552us; 555us; 557us; |]
-let _fsyacc_action_rows = 220
-let _fsyacc_actionTableElements = [|17us; 32768us; 0us; 101us; 3us; 11us; 4us; 5us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 37us; 27us; 41us; 100us; 43us; 13us; 44us; 163us; 46us; 72us; 0us; 49152us; 0us; 16385us; 1us; 32768us; 4us; 4us; 0us; 16386us; 0us; 16387us; 16us; 32768us; 0us; 101us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 37us; 27us; 41us; 100us; 43us; 13us; 44us; 163us; 46us; 72us; 1us; 32768us; 14us; 8us; 0us; 16388us; 16us; 16389us; 0us; 101us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 37us; 27us; 41us; 100us; 43us; 13us; 44us; 163us; 46us; 72us; 0us; 16390us; 0us; 16391us; 0us; 16392us; 0us; 16393us; 0us; 16394us; 2us; 32768us; 3us; 217us; 46us; 185us; 1us; 32768us; 8us; 17us; 0us; 16395us; 0us; 16396us; 0us; 16397us; 0us; 16398us; 0us; 16399us; 0us; 16400us; 0us; 16401us; 0us; 16402us; 2us; 16404us; 36us; 23us; 38us; 24us; 0us; 16403us; 2us; 16406us; 36us; 23us; 38us; 24us; 0us; 16405us; 1us; 16407us; 37us; 27us; 0us; 16408us; 1us; 32768us; 37us; 27us; 1us; 32768us; 24us; 33us; 1us; 16409us; 23us; 31us; 0us; 16410us; 1us; 32768us; 46us; 36us; 2us; 32768us; 0us; 53us; 26us; 37us; 12us; 32768us; 0us; 86us; 21us; 110us; 22us; 122us; 25us; 129us; 29us; 89us; 34us; 109us; 35us; 120us; 36us; 38us; 41us; 100us; 44us; 81us; 45us; 78us; 46us; 107us; 7us; 16435us; 3us; 39us; 11us; 16452us; 23us; 16452us; 30us; 16452us; 33us; 16452us; 39us; 16452us; 40us; 16452us; 0us; 16411us; 5us; 32768us; 2us; 98us; 3us; 41us; 20us; 96us; 21us; 97us; 29us; 99us; 0us; 16412us; 1us; 32768us; 3us; 43us; 0us; 16413us; 1us; 32768us; 3us; 45us; 0us; 16414us; 2us; 16473us; 3us; 47us; 33us; 158us; 0us; 16415us; 1us; 32768us; 3us; 49us; 0us; 16416us; 1us; 16417us; 28us; 51us; 1us; 32768us; 46us; 50us; 0us; 16418us; 2us; 32768us; 1us; 59us; 46us; 50us; 1us; 32768us; 1us; 55us; 1us; 32768us; 26us; 56us; 16us; 32768us; 0us; 101us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 37us; 27us; 41us; 100us; 43us; 13us; 44us; 163us; 46us; 72us; 1us; 32768us; 14us; 58us; 0us; 16419us; 1us; 32768us; 26us; 60us; 16us; 32768us; 0us; 101us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 37us; 27us; 41us; 100us; 43us; 13us; 44us; 163us; 46us; 72us; 1us; 32768us; 14us; 62us; 0us; 16420us; 10us; 16421us; 2us; 16435us; 11us; 16452us; 20us; 16435us; 21us; 16435us; 23us; 16452us; 29us; 16435us; 30us; 16452us; 33us; 16452us; 39us; 16452us; 40us; 16452us; 4us; 16422us; 2us; 98us; 20us; 96us; 21us; 97us; 29us; 99us; 0us; 16423us; 0us; 16424us; 1us; 16425us; 33us; 158us; 0us; 16426us; 1us; 16428us; 28us; 70us; 12us; 32768us; 0us; 86us; 21us; 110us; 22us; 122us; 25us; 129us; 29us; 89us; 34us; 109us; 35us; 120us; 36us; 63us; 41us; 100us; 44us; 81us; 45us; 78us; 46us; 107us; 0us; 16427us; 3us; 16445us; 0us; 73us; 11us; 170us; 27us; 16476us; 13us; 32768us; 0us; 86us; 1us; 76us; 21us; 110us; 22us; 122us; 25us; 129us; 29us; 89us; 34us; 109us; 35us; 120us; 36us; 63us; 41us; 100us; 44us; 81us; 45us; 78us; 46us; 107us; 1us; 32768us; 1us; 75us; 0us; 16429us; 0us; 16430us; 0us; 16431us; 1us; 16431us; 11us; 79us; 1us; 32768us; 45us; 80us; 0us; 16432us; 0us; 16433us; 0us; 16434us; 0us; 16435us; 6us; 16435us; 11us; 16452us; 23us; 16452us; 30us; 16452us; 33us; 16452us; 39us; 16452us; 40us; 16452us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 11us; 32768us; 0us; 86us; 21us; 110us; 22us; 122us; 25us; 129us; 29us; 89us; 34us; 109us; 35us; 120us; 36us; 84us; 41us; 100us; 45us; 77us; 46us; 107us; 5us; 32768us; 1us; 88us; 2us; 98us; 20us; 96us; 21us; 97us; 29us; 99us; 0us; 16436us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 0us; 16437us; 0us; 16438us; 0us; 16439us; 2us; 16440us; 20us; 96us; 21us; 97us; 2us; 16441us; 20us; 96us; 21us; 97us; 5us; 16461us; 2us; 98us; 20us; 96us; 21us; 97us; 29us; 99us; 46us; 132us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 0us; 16442us; 9us; 32768us; 0us; 101us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 41us; 100us; 46us; 107us; 1us; 32768us; 1us; 103us; 0us; 16443us; 1us; 32768us; 29us; 105us; 1us; 32768us; 46us; 106us; 0us; 16444us; 0us; 16445us; 1us; 16445us; 11us; 170us; 0us; 16446us; 2us; 32768us; 31us; 113us; 46us; 111us; 1us; 32768us; 21us; 112us; 0us; 16447us; 2us; 32768us; 20us; 118us; 46us; 114us; 2us; 32768us; 20us; 116us; 21us; 115us; 0us; 16448us; 1us; 32768us; 21us; 117us; 0us; 16449us; 1us; 32768us; 21us; 119us; 0us; 16450us; 0us; 16451us; 0us; 16452us; 1us; 32768us; 46us; 123us; 0us; 16453us; 4us; 16454us; 11us; 152us; 30us; 133us; 39us; 149us; 40us; 150us; 4us; 16455us; 11us; 152us; 30us; 133us; 39us; 149us; 40us; 150us; 1us; 16457us; 23us; 31us; 0us; 16456us; 0us; 16458us; 8us; 32768us; 0us; 101us; 21us; 110us; 22us; 122us; 34us; 109us; 35us; 120us; 36us; 121us; 41us; 100us; 46us; 107us; 0us; 16459us; 0us; 16460us; 0us; 16462us; 5us; 32768us; 0us; 85us; 29us; 89us; 35us; 138us; 36us; 83us; 45us; 77us; 1us; 32768us; 19us; 135us; 5us; 32768us; 0us; 85us; 29us; 89us; 35us; 143us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 137us; 0us; 16463us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 1us; 32768us; 19us; 140us; 5us; 32768us; 0us; 85us; 29us; 89us; 35us; 146us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 142us; 0us; 16464us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 145us; 0us; 16465us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 148us; 0us; 16466us; 0us; 16467us; 0us; 16468us; 0us; 16469us; 1us; 32768us; 46us; 153us; 0us; 16470us; 0us; 16471us; 0us; 16472us; 1us; 16473us; 33us; 158us; 2us; 16473us; 9us; 16483us; 33us; 158us; 9us; 32768us; 0us; 101us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 41us; 100us; 46us; 107us; 0us; 16474us; 0us; 16475us; 0us; 16476us; 0us; 16477us; 2us; 16477us; 9us; 16480us; 11us; 168us; 1us; 16478us; 11us; 165us; 2us; 32768us; 44us; 162us; 46us; 161us; 0us; 16479us; 1us; 16480us; 11us; 168us; 1us; 32768us; 44us; 169us; 0us; 16481us; 1us; 32768us; 46us; 171us; 0us; 16482us; 0us; 16483us; 1us; 32768us; 27us; 174us; 0us; 16484us; 1us; 32768us; 9us; 176us; 2us; 32768us; 44us; 162us; 46us; 161us; 0us; 16485us; 1us; 16486us; 33us; 179us; 10us; 32768us; 0us; 101us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 41us; 100us; 44us; 167us; 46us; 108us; 0us; 16487us; 1us; 16488us; 33us; 182us; 10us; 32768us; 0us; 101us; 21us; 110us; 22us; 122us; 25us; 129us; 34us; 109us; 35us; 120us; 36us; 121us; 41us; 100us; 44us; 167us; 46us; 108us; 0us; 16489us; 0us; 16490us; 1us; 16491us; 11us; 186us; 1us; 32768us; 46us; 187us; 0us; 16492us; 1us; 32768us; 46us; 189us; 1us; 32768us; 32us; 190us; 0us; 16493us; 0us; 16494us; 1us; 32768us; 9us; 195us; 2us; 32768us; 9us; 195us; 10us; 197us; 3us; 32768us; 9us; 195us; 10us; 197us; 27us; 209us; 1us; 32768us; 46us; 185us; 0us; 16496us; 1us; 32768us; 46us; 185us; 0us; 16497us; 1us; 16495us; 30us; 188us; 0us; 16498us; 1us; 32768us; 29us; 202us; 1us; 32768us; 46us; 185us; 1us; 16495us; 30us; 188us; 0us; 16499us; 1us; 16500us; 19us; 206us; 1us; 32768us; 19us; 207us; 1us; 32768us; 46us; 185us; 0us; 16501us; 1us; 16502us; 30us; 188us; 0us; 16503us; 1us; 16504us; 19us; 212us; 1us; 32768us; 19us; 213us; 1us; 32768us; 46us; 185us; 0us; 16505us; 0us; 16506us; 2us; 16507us; 3us; 217us; 46us; 185us; 2us; 16509us; 3us; 217us; 46us; 185us; 0us; 16508us; 0us; 16510us; |]
-let _fsyacc_actionTableRowOffsets = [|0us; 18us; 19us; 20us; 22us; 23us; 24us; 41us; 43us; 44us; 61us; 62us; 63us; 64us; 65us; 66us; 69us; 71us; 72us; 73us; 74us; 75us; 76us; 77us; 78us; 79us; 82us; 83us; 86us; 87us; 89us; 90us; 92us; 94us; 96us; 97us; 99us; 102us; 115us; 123us; 124us; 130us; 131us; 133us; 134us; 136us; 137us; 140us; 141us; 143us; 144us; 146us; 148us; 149us; 152us; 154us; 156us; 173us; 175us; 176us; 178us; 195us; 197us; 198us; 209us; 214us; 215us; 216us; 218us; 219us; 221us; 234us; 235us; 239us; 253us; 255us; 256us; 257us; 258us; 260us; 262us; 263us; 264us; 265us; 266us; 273us; 278us; 290us; 296us; 297us; 302us; 303us; 304us; 305us; 308us; 311us; 317us; 322us; 327us; 332us; 337us; 338us; 348us; 350us; 351us; 353us; 355us; 356us; 357us; 359us; 360us; 363us; 365us; 366us; 369us; 372us; 373us; 375us; 376us; 378us; 379us; 380us; 381us; 383us; 384us; 389us; 394us; 396us; 397us; 398us; 407us; 408us; 409us; 410us; 416us; 418us; 424us; 426us; 427us; 432us; 434us; 440us; 442us; 443us; 448us; 450us; 451us; 456us; 458us; 459us; 460us; 461us; 462us; 464us; 465us; 466us; 467us; 469us; 472us; 482us; 483us; 484us; 485us; 486us; 489us; 491us; 494us; 495us; 497us; 499us; 500us; 502us; 503us; 504us; 506us; 507us; 509us; 512us; 513us; 515us; 526us; 527us; 529us; 540us; 541us; 542us; 544us; 546us; 547us; 549us; 551us; 552us; 553us; 555us; 558us; 562us; 564us; 565us; 567us; 568us; 570us; 571us; 573us; 575us; 577us; 578us; 580us; 582us; 584us; 585us; 587us; 588us; 590us; 592us; 594us; 595us; 596us; 599us; 602us; 603us; |]
-let _fsyacc_reductionSymbolCounts = [|1us; 1us; 2us; 1us; 3us; 1us; 2us; 1us; 1us; 1us; 1us; 3us; 1us; 1us; 1us; 1us; 1us; 1us; 1us; 2us; 1us; 2us; 1us; 1us; 2us; 3us; 4us; 5us; 5us; 5us; 5us; 5us; 5us; 1us; 3us; 8us; 7us; 1us; 1us; 1us; 1us; 1us; 1us; 3us; 1us; 4us; 3us; 1us; 3us; 1us; 1us; 1us; 3us; 2us; 3us; 3us; 3us; 3us; 1us; 3us; 3us; 1us; 1us; 3us; 4us; 5us; 4us; 1us; 1us; 2us; 1us; 2us; 2us; 1us; 1us; 2us; 1us; 1us; 2us; 5us; 6us; 6us; 7us; 1us; 1us; 1us; 2us; 1us; 2us; 1us; 3us; 1us; 1us; 1us; 1us; 3us; 1us; 3us; 3us; 1us; 2us; 3us; 1us; 3us; 1us; 3us; 1us; 1us; 3us; 3us; 1us; 0us; 3us; 3us; 2us; 4us; 1us; 4us; 2us; 3us; 1us; 4us; 1us; 1us; 2us; 1us; 2us; |]
-let _fsyacc_productionToNonTerminalTable = [|0us; 1us; 2us; 2us; 3us; 4us; 4us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 6us; 6us; 7us; 7us; 8us; 8us; 9us; 9us; 10us; 10us; 11us; 11us; 11us; 11us; 11us; 11us; 12us; 12us; 13us; 13us; 14us; 14us; 14us; 14us; 14us; 14us; 15us; 15us; 16us; 16us; 17us; 18us; 19us; 20us; 20us; 20us; 20us; 20us; 20us; 20us; 20us; 21us; 22us; 22us; 22us; 22us; 22us; 22us; 22us; 22us; 22us; 22us; 22us; 23us; 23us; 24us; 24us; 25us; 25us; 26us; 27us; 27us; 28us; 28us; 28us; 28us; 29us; 29us; 29us; 29us; 30us; 30us; 31us; 31us; 32us; 33us; 33us; 34us; 34us; 35us; 35us; 35us; 35us; 36us; 37us; 38us; 38us; 39us; 39us; 39us; 40us; 40us; 41us; 42us; 42us; 43us; 44us; 45us; 45us; 46us; 46us; 47us; 47us; 48us; 48us; 48us; 49us; 49us; 49us; 49us; |]
-let _fsyacc_immediateActions = [|65535us; 49152us; 16385us; 65535us; 16386us; 16387us; 65535us; 65535us; 16388us; 65535us; 16390us; 16391us; 16392us; 16393us; 16394us; 65535us; 65535us; 16395us; 16396us; 16397us; 16398us; 16399us; 16400us; 16401us; 16402us; 65535us; 16403us; 65535us; 16405us; 65535us; 16408us; 65535us; 65535us; 65535us; 16410us; 65535us; 65535us; 65535us; 65535us; 16411us; 65535us; 16412us; 65535us; 16413us; 65535us; 16414us; 65535us; 16415us; 65535us; 16416us; 65535us; 65535us; 16418us; 65535us; 65535us; 65535us; 65535us; 65535us; 16419us; 65535us; 65535us; 65535us; 16420us; 65535us; 65535us; 16423us; 16424us; 65535us; 16426us; 65535us; 65535us; 16427us; 65535us; 65535us; 65535us; 16429us; 16430us; 16431us; 65535us; 65535us; 16432us; 16433us; 16434us; 16435us; 65535us; 65535us; 65535us; 65535us; 16436us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 16442us; 65535us; 65535us; 16443us; 65535us; 65535us; 16444us; 16445us; 65535us; 16446us; 65535us; 65535us; 16447us; 65535us; 65535us; 16448us; 65535us; 16449us; 65535us; 16450us; 16451us; 16452us; 65535us; 16453us; 65535us; 65535us; 65535us; 16456us; 16458us; 65535us; 16459us; 16460us; 16462us; 65535us; 65535us; 65535us; 65535us; 16463us; 65535us; 65535us; 65535us; 65535us; 16464us; 65535us; 65535us; 16465us; 65535us; 65535us; 16466us; 16467us; 16468us; 16469us; 65535us; 16470us; 16471us; 16472us; 65535us; 65535us; 65535us; 16474us; 16475us; 16476us; 16477us; 65535us; 65535us; 65535us; 16479us; 65535us; 65535us; 16481us; 65535us; 16482us; 16483us; 65535us; 16484us; 65535us; 65535us; 16485us; 65535us; 65535us; 16487us; 65535us; 65535us; 16489us; 16490us; 65535us; 65535us; 16492us; 65535us; 65535us; 16493us; 16494us; 65535us; 65535us; 65535us; 65535us; 16496us; 65535us; 16497us; 65535us; 16498us; 65535us; 65535us; 65535us; 16499us; 65535us; 65535us; 65535us; 16501us; 65535us; 16503us; 65535us; 65535us; 65535us; 16505us; 16506us; 65535us; 65535us; 16508us; 16510us; |]
+let _fsyacc_gotos = [| 0us; 65535us; 1us; 65535us; 0us; 1us; 1us; 65535us; 0us; 2us; 5us; 65535us; 0us; 22us; 6us; 22us; 9us; 22us; 56us; 22us; 60us; 22us; 5us; 65535us; 0us; 3us; 6us; 7us; 9us; 10us; 56us; 57us; 60us; 61us; 5us; 65535us; 0us; 9us; 6us; 9us; 9us; 9us; 56us; 9us; 60us; 9us; 2us; 65535us; 25us; 25us; 27us; 25us; 2us; 65535us; 25us; 26us; 27us; 28us; 7us; 65535us; 0us; 18us; 6us; 18us; 9us; 18us; 29us; 29us; 31us; 29us; 56us; 18us; 60us; 18us; 2us; 65535us; 29us; 30us; 31us; 32us; 2us; 65535us; 33us; 34us; 122us; 123us; 5us; 65535us; 0us; 19us; 6us; 19us; 9us; 19us; 56us; 19us; 60us; 19us; 2us; 65535us; 51us; 52us; 53us; 54us; 5us; 65535us; 0us; 21us; 6us; 21us; 9us; 21us; 56us; 21us; 60us; 21us; 2us; 65535us; 70us; 69us; 73us; 69us; 2us; 65535us; 70us; 71us; 73us; 74us; 5us; 65535us; 0us; 20us; 6us; 20us; 9us; 20us; 56us; 20us; 60us; 20us; 16us; 65535us; 37us; 82us; 70us; 82us; 73us; 82us; 85us; 82us; 86us; 82us; 89us; 82us; 96us; 82us; 97us; 82us; 98us; 82us; 99us; 82us; 129us; 82us; 131us; 82us; 134us; 82us; 136us; 82us; 139us; 82us; 142us; 82us; 3us; 65535us; 37us; 44us; 70us; 66us; 73us; 66us; 3us; 65535us; 37us; 42us; 70us; 65us; 73us; 65us; 16us; 65535us; 37us; 40us; 70us; 64us; 73us; 64us; 85us; 87us; 86us; 87us; 89us; 90us; 96us; 91us; 97us; 92us; 98us; 93us; 99us; 94us; 129us; 95us; 131us; 95us; 134us; 95us; 136us; 95us; 139us; 95us; 142us; 95us; 14us; 65535us; 0us; 120us; 6us; 120us; 9us; 120us; 37us; 120us; 56us; 120us; 60us; 120us; 70us; 120us; 73us; 120us; 86us; 120us; 100us; 120us; 125us; 120us; 154us; 120us; 175us; 120us; 178us; 120us; 14us; 65535us; 0us; 122us; 6us; 122us; 9us; 122us; 37us; 122us; 56us; 122us; 60us; 122us; 70us; 122us; 73us; 122us; 86us; 122us; 100us; 122us; 125us; 122us; 154us; 122us; 175us; 122us; 178us; 122us; 14us; 65535us; 0us; 124us; 6us; 124us; 9us; 124us; 37us; 124us; 56us; 124us; 60us; 124us; 70us; 124us; 73us; 124us; 86us; 124us; 100us; 124us; 125us; 126us; 154us; 124us; 175us; 124us; 178us; 124us; 13us; 65535us; 0us; 127us; 6us; 127us; 9us; 127us; 37us; 127us; 56us; 127us; 60us; 127us; 70us; 127us; 73us; 127us; 86us; 127us; 100us; 127us; 154us; 127us; 175us; 127us; 178us; 127us; 13us; 65535us; 0us; 153us; 6us; 153us; 9us; 153us; 37us; 46us; 56us; 153us; 60us; 153us; 70us; 67us; 73us; 67us; 86us; 152us; 100us; 152us; 154us; 152us; 175us; 168us; 178us; 168us; 6us; 65535us; 129us; 130us; 131us; 132us; 134us; 135us; 136us; 137us; 139us; 140us; 142us; 143us; 2us; 65535us; 120us; 147us; 121us; 147us; 2us; 65535us; 120us; 150us; 121us; 151us; 1us; 65535us; 120us; 121us; 11us; 65535us; 0us; 156us; 6us; 156us; 9us; 156us; 37us; 156us; 56us; 156us; 60us; 156us; 70us; 156us; 73us; 156us; 86us; 156us; 100us; 156us; 154us; 155us; 10us; 65535us; 0us; 12us; 6us; 12us; 9us; 12us; 37us; 48us; 56us; 12us; 60us; 12us; 70us; 68us; 73us; 68us; 86us; 101us; 100us; 101us; 7us; 65535us; 0us; 160us; 6us; 160us; 9us; 160us; 56us; 160us; 60us; 160us; 161us; 162us; 172us; 160us; 6us; 65535us; 0us; 169us; 6us; 169us; 9us; 169us; 56us; 169us; 60us; 169us; 172us; 173us; 7us; 65535us; 0us; 171us; 6us; 171us; 9us; 171us; 56us; 171us; 60us; 171us; 175us; 171us; 178us; 171us; 5us; 65535us; 0us; 177us; 6us; 177us; 9us; 177us; 56us; 177us; 60us; 177us; 7us; 65535us; 0us; 174us; 6us; 174us; 9us; 174us; 56us; 174us; 60us; 174us; 175us; 174us; 178us; 174us; 7us; 65535us; 0us; 180us; 6us; 180us; 9us; 180us; 56us; 180us; 60us; 180us; 175us; 176us; 178us; 179us; 5us; 65535us; 0us; 14us; 6us; 14us; 9us; 14us; 56us; 14us; 60us; 14us; 8us; 65535us; 15us; 190us; 191us; 192us; 193us; 194us; 198us; 188us; 203us; 189us; 209us; 189us; 212us; 190us; 213us; 190us; 3us; 65535us; 195us; 187us; 199us; 187us; 205us; 206us; 2us; 65535us; 195us; 196us; 199us; 200us; 6us; 65535us; 15us; 195us; 198us; 199us; 203us; 195us; 209us; 195us; 212us; 195us; 213us; 195us; 5us; 65535us; 15us; 197us; 203us; 197us; 209us; 197us; 212us; 197us; 213us; 197us; 5us; 65535us; 15us; 201us; 203us; 201us; 209us; 201us; 212us; 201us; 213us; 201us; 5us; 65535us; 15us; 211us; 203us; 204us; 209us; 210us; 212us; 211us; 213us; 211us; 3us; 65535us; 15us; 207us; 212us; 207us; 213us; 207us; 3us; 65535us; 15us; 212us; 212us; 212us; 213us; 212us; 3us; 65535us; 15us; 16us; 212us; 215us; 213us; 214us; |]
+let _fsyacc_sparseGotoTableRowOffsets = [|0us; 1us; 3us; 5us; 11us; 17us; 23us; 26us; 29us; 37us; 40us; 43us; 49us; 52us; 58us; 61us; 64us; 70us; 87us; 91us; 95us; 112us; 127us; 142us; 157us; 171us; 185us; 192us; 195us; 198us; 200us; 212us; 223us; 231us; 238us; 246us; 252us; 260us; 268us; 274us; 283us; 287us; 290us; 297us; 303us; 309us; 315us; 319us; 323us; |]
+let _fsyacc_stateToProdIdxsTableElements = [| 1us; 0us; 1us; 0us; 1us; 1us; 1us; 2us; 1us; 2us; 1us; 3us; 1us; 4us; 1us; 4us; 1us; 4us; 2us; 5us; 6us; 1us; 6us; 1us; 7us; 1us; 8us; 1us; 9us; 1us; 10us; 1us; 11us; 1us; 11us; 1us; 11us; 1us; 12us; 1us; 13us; 1us; 14us; 1us; 15us; 1us; 16us; 1us; 17us; 1us; 18us; 2us; 19us; 20us; 1us; 19us; 2us; 21us; 22us; 1us; 21us; 2us; 23us; 24us; 1us; 24us; 2us; 25us; 26us; 2us; 25us; 26us; 2us; 25us; 26us; 1us; 26us; 8us; 27us; 28us; 29us; 30us; 31us; 32us; 35us; 36us; 8us; 27us; 28us; 29us; 30us; 31us; 32us; 35us; 36us; 6us; 27us; 28us; 29us; 30us; 31us; 32us; 3us; 27us; 51us; 66us; 1us; 27us; 5us; 28us; 54us; 55us; 56us; 57us; 1us; 28us; 1us; 29us; 1us; 29us; 1us; 30us; 1us; 30us; 3us; 31us; 87us; 88us; 1us; 31us; 1us; 32us; 1us; 32us; 2us; 33us; 34us; 1us; 34us; 1us; 34us; 2us; 35us; 36us; 1us; 35us; 1us; 35us; 1us; 35us; 1us; 35us; 1us; 35us; 1us; 36us; 1us; 36us; 1us; 36us; 1us; 36us; 3us; 37us; 51us; 66us; 5us; 38us; 54us; 55us; 56us; 57us; 1us; 39us; 1us; 40us; 3us; 41us; 87us; 88us; 1us; 42us; 2us; 43us; 44us; 1us; 43us; 1us; 43us; 5us; 45us; 46us; 59us; 90us; 96us; 2us; 45us; 46us; 1us; 45us; 1us; 45us; 1us; 46us; 1us; 47us; 2us; 47us; 48us; 1us; 48us; 1us; 48us; 1us; 49us; 1us; 50us; 1us; 51us; 2us; 51us; 66us; 1us; 52us; 2us; 52us; 58us; 5us; 52us; 54us; 55us; 56us; 57us; 1us; 52us; 1us; 53us; 5us; 53us; 54us; 55us; 56us; 57us; 5us; 54us; 54us; 55us; 56us; 57us; 5us; 54us; 55us; 55us; 56us; 57us; 5us; 54us; 55us; 56us; 56us; 57us; 5us; 54us; 55us; 56us; 57us; 57us; 6us; 54us; 55us; 56us; 57us; 75us; 76us; 1us; 54us; 1us; 55us; 1us; 56us; 1us; 57us; 1us; 58us; 1us; 58us; 1us; 58us; 1us; 59us; 2us; 59us; 96us; 1us; 60us; 4us; 61us; 62us; 63us; 64us; 1us; 61us; 1us; 61us; 3us; 62us; 63us; 64us; 2us; 62us; 63us; 1us; 62us; 1us; 63us; 1us; 63us; 1us; 64us; 1us; 64us; 1us; 65us; 1us; 66us; 1us; 67us; 1us; 67us; 2us; 68us; 69us; 2us; 69us; 86us; 2us; 70us; 71us; 1us; 70us; 1us; 72us; 1us; 73us; 1us; 73us; 1us; 74us; 1us; 76us; 4us; 77us; 78us; 79us; 80us; 2us; 77us; 79us; 2us; 77us; 79us; 1us; 77us; 1us; 77us; 2us; 78us; 80us; 2us; 78us; 80us; 2us; 78us; 80us; 1us; 78us; 1us; 78us; 1us; 79us; 1us; 79us; 1us; 79us; 1us; 80us; 1us; 80us; 1us; 80us; 1us; 81us; 1us; 82us; 1us; 83us; 1us; 84us; 1us; 84us; 1us; 85us; 1us; 86us; 2us; 87us; 88us; 3us; 87us; 88us; 97us; 1us; 88us; 1us; 88us; 1us; 89us; 1us; 90us; 1us; 91us; 3us; 91us; 94us; 95us; 2us; 92us; 93us; 1us; 93us; 1us; 93us; 2us; 94us; 95us; 1us; 95us; 1us; 95us; 1us; 96us; 1us; 96us; 1us; 97us; 1us; 98us; 1us; 98us; 1us; 99us; 1us; 99us; 1us; 99us; 2us; 100us; 101us; 1us; 101us; 1us; 101us; 2us; 102us; 103us; 1us; 103us; 1us; 103us; 1us; 104us; 2us; 105us; 106us; 1us; 106us; 1us; 106us; 1us; 107us; 1us; 107us; 1us; 107us; 1us; 108us; 1us; 110us; 2us; 110us; 111us; 4us; 110us; 111us; 116us; 117us; 1us; 110us; 1us; 110us; 1us; 111us; 1us; 111us; 1us; 112us; 1us; 112us; 1us; 113us; 1us; 113us; 1us; 113us; 1us; 113us; 2us; 114us; 115us; 1us; 115us; 1us; 115us; 1us; 115us; 2us; 116us; 117us; 1us; 117us; 2us; 118us; 119us; 1us; 119us; 1us; 119us; 1us; 119us; 1us; 120us; 2us; 121us; 124us; 2us; 122us; 123us; 1us; 122us; 1us; 124us; |]
+let _fsyacc_stateToProdIdxsTableRowOffsets = [|0us; 2us; 4us; 6us; 8us; 10us; 12us; 14us; 16us; 18us; 21us; 23us; 25us; 27us; 29us; 31us; 33us; 35us; 37us; 39us; 41us; 43us; 45us; 47us; 49us; 51us; 54us; 56us; 59us; 61us; 64us; 66us; 69us; 72us; 75us; 77us; 86us; 95us; 102us; 106us; 108us; 114us; 116us; 118us; 120us; 122us; 124us; 128us; 130us; 132us; 134us; 137us; 139us; 141us; 144us; 146us; 148us; 150us; 152us; 154us; 156us; 158us; 160us; 162us; 166us; 172us; 174us; 176us; 180us; 182us; 185us; 187us; 189us; 195us; 198us; 200us; 202us; 204us; 206us; 209us; 211us; 213us; 215us; 217us; 219us; 222us; 224us; 227us; 233us; 235us; 237us; 243us; 249us; 255us; 261us; 267us; 274us; 276us; 278us; 280us; 282us; 284us; 286us; 288us; 290us; 293us; 295us; 300us; 302us; 304us; 308us; 311us; 313us; 315us; 317us; 319us; 321us; 323us; 325us; 327us; 329us; 332us; 335us; 338us; 340us; 342us; 344us; 346us; 348us; 350us; 355us; 358us; 361us; 363us; 365us; 368us; 371us; 374us; 376us; 378us; 380us; 382us; 384us; 386us; 388us; 390us; 392us; 394us; 396us; 398us; 400us; 402us; 404us; 407us; 411us; 413us; 415us; 417us; 419us; 421us; 425us; 428us; 430us; 432us; 435us; 437us; 439us; 441us; 443us; 445us; 447us; 449us; 451us; 453us; 455us; 458us; 460us; 462us; 465us; 467us; 469us; 471us; 474us; 476us; 478us; 480us; 482us; 484us; 486us; 488us; 491us; 496us; 498us; 500us; 502us; 504us; 506us; 508us; 510us; 512us; 514us; 516us; 519us; 521us; 523us; 525us; 528us; 530us; 533us; 535us; 537us; 539us; 541us; 544us; 547us; 549us; |]
+let _fsyacc_action_rows = 216
+let _fsyacc_actionTableElements = [|16us; 32768us; 0us; 100us; 3us; 11us; 4us; 5us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 37us; 27us; 43us; 13us; 44us; 159us; 46us; 72us; 0us; 49152us; 0us; 16385us; 1us; 32768us; 4us; 4us; 0us; 16386us; 0us; 16387us; 15us; 32768us; 0us; 100us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 37us; 27us; 43us; 13us; 44us; 159us; 46us; 72us; 1us; 32768us; 14us; 8us; 0us; 16388us; 15us; 16389us; 0us; 100us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 37us; 27us; 43us; 13us; 44us; 159us; 46us; 72us; 0us; 16390us; 0us; 16391us; 0us; 16392us; 0us; 16393us; 0us; 16394us; 2us; 32768us; 3us; 213us; 46us; 181us; 1us; 32768us; 8us; 17us; 0us; 16395us; 0us; 16396us; 0us; 16397us; 0us; 16398us; 0us; 16399us; 0us; 16400us; 0us; 16401us; 0us; 16402us; 2us; 16404us; 36us; 23us; 38us; 24us; 0us; 16403us; 2us; 16406us; 36us; 23us; 38us; 24us; 0us; 16405us; 1us; 16407us; 37us; 27us; 0us; 16408us; 1us; 32768us; 37us; 27us; 1us; 32768us; 24us; 33us; 1us; 16409us; 23us; 31us; 0us; 16410us; 1us; 32768us; 46us; 36us; 2us; 32768us; 0us; 53us; 26us; 37us; 11us; 32768us; 0us; 86us; 21us; 106us; 22us; 118us; 25us; 125us; 29us; 89us; 34us; 105us; 35us; 116us; 36us; 38us; 44us; 81us; 45us; 78us; 46us; 103us; 7us; 16435us; 3us; 39us; 11us; 16450us; 23us; 16450us; 30us; 16450us; 33us; 16450us; 39us; 16450us; 40us; 16450us; 0us; 16411us; 5us; 32768us; 2us; 98us; 3us; 41us; 20us; 96us; 21us; 97us; 29us; 99us; 0us; 16412us; 1us; 32768us; 3us; 43us; 0us; 16413us; 1us; 32768us; 3us; 45us; 0us; 16414us; 2us; 16471us; 3us; 47us; 33us; 154us; 0us; 16415us; 1us; 32768us; 3us; 49us; 0us; 16416us; 1us; 16417us; 28us; 51us; 1us; 32768us; 46us; 50us; 0us; 16418us; 2us; 32768us; 1us; 59us; 46us; 50us; 1us; 32768us; 1us; 55us; 1us; 32768us; 26us; 56us; 15us; 32768us; 0us; 100us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 37us; 27us; 43us; 13us; 44us; 159us; 46us; 72us; 1us; 32768us; 14us; 58us; 0us; 16419us; 1us; 32768us; 26us; 60us; 15us; 32768us; 0us; 100us; 3us; 11us; 7us; 15us; 12us; 35us; 18us; 6us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 37us; 27us; 43us; 13us; 44us; 159us; 46us; 72us; 1us; 32768us; 14us; 62us; 0us; 16420us; 10us; 16421us; 2us; 16435us; 11us; 16450us; 20us; 16435us; 21us; 16435us; 23us; 16450us; 29us; 16435us; 30us; 16450us; 33us; 16450us; 39us; 16450us; 40us; 16450us; 4us; 16422us; 2us; 98us; 20us; 96us; 21us; 97us; 29us; 99us; 0us; 16423us; 0us; 16424us; 1us; 16425us; 33us; 154us; 0us; 16426us; 1us; 16428us; 28us; 70us; 11us; 32768us; 0us; 86us; 21us; 106us; 22us; 118us; 25us; 125us; 29us; 89us; 34us; 105us; 35us; 116us; 36us; 63us; 44us; 81us; 45us; 78us; 46us; 103us; 0us; 16427us; 3us; 16443us; 0us; 73us; 11us; 166us; 27us; 16474us; 12us; 32768us; 0us; 86us; 1us; 76us; 21us; 106us; 22us; 118us; 25us; 125us; 29us; 89us; 34us; 105us; 35us; 116us; 36us; 63us; 44us; 81us; 45us; 78us; 46us; 103us; 1us; 32768us; 1us; 75us; 0us; 16429us; 0us; 16430us; 0us; 16431us; 1us; 16431us; 11us; 79us; 1us; 32768us; 45us; 80us; 0us; 16432us; 0us; 16433us; 0us; 16434us; 0us; 16435us; 6us; 16435us; 11us; 16450us; 23us; 16450us; 30us; 16450us; 33us; 16450us; 39us; 16450us; 40us; 16450us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 10us; 32768us; 0us; 86us; 21us; 106us; 22us; 118us; 25us; 125us; 29us; 89us; 34us; 105us; 35us; 116us; 36us; 84us; 45us; 77us; 46us; 103us; 5us; 32768us; 1us; 88us; 2us; 98us; 20us; 96us; 21us; 97us; 29us; 99us; 0us; 16436us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 0us; 16437us; 0us; 16438us; 0us; 16439us; 2us; 16440us; 20us; 96us; 21us; 97us; 2us; 16441us; 20us; 96us; 21us; 97us; 5us; 16459us; 2us; 98us; 20us; 96us; 21us; 97us; 29us; 99us; 46us; 128us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 8us; 32768us; 0us; 100us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 46us; 103us; 1us; 32768us; 1us; 102us; 0us; 16442us; 0us; 16443us; 1us; 16443us; 11us; 166us; 0us; 16444us; 2us; 32768us; 31us; 109us; 46us; 107us; 1us; 32768us; 21us; 108us; 0us; 16445us; 2us; 32768us; 20us; 114us; 46us; 110us; 2us; 32768us; 20us; 112us; 21us; 111us; 0us; 16446us; 1us; 32768us; 21us; 113us; 0us; 16447us; 1us; 32768us; 21us; 115us; 0us; 16448us; 0us; 16449us; 0us; 16450us; 1us; 32768us; 46us; 119us; 0us; 16451us; 4us; 16452us; 11us; 148us; 30us; 129us; 39us; 145us; 40us; 146us; 4us; 16453us; 11us; 148us; 30us; 129us; 39us; 145us; 40us; 146us; 1us; 16455us; 23us; 31us; 0us; 16454us; 0us; 16456us; 7us; 32768us; 0us; 100us; 21us; 106us; 22us; 118us; 34us; 105us; 35us; 116us; 36us; 117us; 46us; 103us; 0us; 16457us; 0us; 16458us; 0us; 16460us; 5us; 32768us; 0us; 85us; 29us; 89us; 35us; 134us; 36us; 83us; 45us; 77us; 1us; 32768us; 19us; 131us; 5us; 32768us; 0us; 85us; 29us; 89us; 35us; 139us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 133us; 0us; 16461us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 1us; 32768us; 19us; 136us; 5us; 32768us; 0us; 85us; 29us; 89us; 35us; 142us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 138us; 0us; 16462us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 141us; 0us; 16463us; 4us; 32768us; 0us; 85us; 29us; 89us; 36us; 83us; 45us; 77us; 1us; 32768us; 32us; 144us; 0us; 16464us; 0us; 16465us; 0us; 16466us; 0us; 16467us; 1us; 32768us; 46us; 149us; 0us; 16468us; 0us; 16469us; 0us; 16470us; 1us; 16471us; 33us; 154us; 2us; 16471us; 9us; 16481us; 33us; 154us; 8us; 32768us; 0us; 100us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 46us; 103us; 0us; 16472us; 0us; 16473us; 0us; 16474us; 0us; 16475us; 2us; 16475us; 9us; 16478us; 11us; 164us; 1us; 16476us; 11us; 161us; 2us; 32768us; 44us; 158us; 46us; 157us; 0us; 16477us; 1us; 16478us; 11us; 164us; 1us; 32768us; 44us; 165us; 0us; 16479us; 1us; 32768us; 46us; 167us; 0us; 16480us; 0us; 16481us; 1us; 32768us; 27us; 170us; 0us; 16482us; 1us; 32768us; 9us; 172us; 2us; 32768us; 44us; 158us; 46us; 157us; 0us; 16483us; 1us; 16484us; 33us; 175us; 9us; 32768us; 0us; 100us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 44us; 163us; 46us; 104us; 0us; 16485us; 1us; 16486us; 33us; 178us; 9us; 32768us; 0us; 100us; 21us; 106us; 22us; 118us; 25us; 125us; 34us; 105us; 35us; 116us; 36us; 117us; 44us; 163us; 46us; 104us; 0us; 16487us; 0us; 16488us; 1us; 16489us; 11us; 182us; 1us; 32768us; 46us; 183us; 0us; 16490us; 1us; 32768us; 46us; 185us; 1us; 32768us; 32us; 186us; 0us; 16491us; 0us; 16492us; 1us; 32768us; 9us; 191us; 2us; 32768us; 9us; 191us; 10us; 193us; 3us; 32768us; 9us; 191us; 10us; 193us; 27us; 205us; 1us; 32768us; 46us; 181us; 0us; 16494us; 1us; 32768us; 46us; 181us; 0us; 16495us; 1us; 16493us; 30us; 184us; 0us; 16496us; 1us; 32768us; 29us; 198us; 1us; 32768us; 46us; 181us; 1us; 16493us; 30us; 184us; 0us; 16497us; 1us; 16498us; 19us; 202us; 1us; 32768us; 19us; 203us; 1us; 32768us; 46us; 181us; 0us; 16499us; 1us; 16500us; 30us; 184us; 0us; 16501us; 1us; 16502us; 19us; 208us; 1us; 32768us; 19us; 209us; 1us; 32768us; 46us; 181us; 0us; 16503us; 0us; 16504us; 2us; 16505us; 3us; 213us; 46us; 181us; 2us; 16507us; 3us; 213us; 46us; 181us; 0us; 16506us; 0us; 16508us; |]
+let _fsyacc_actionTableRowOffsets = [|0us; 17us; 18us; 19us; 21us; 22us; 23us; 39us; 41us; 42us; 58us; 59us; 60us; 61us; 62us; 63us; 66us; 68us; 69us; 70us; 71us; 72us; 73us; 74us; 75us; 76us; 79us; 80us; 83us; 84us; 86us; 87us; 89us; 91us; 93us; 94us; 96us; 99us; 111us; 119us; 120us; 126us; 127us; 129us; 130us; 132us; 133us; 136us; 137us; 139us; 140us; 142us; 144us; 145us; 148us; 150us; 152us; 168us; 170us; 171us; 173us; 189us; 191us; 192us; 203us; 208us; 209us; 210us; 212us; 213us; 215us; 227us; 228us; 232us; 245us; 247us; 248us; 249us; 250us; 252us; 254us; 255us; 256us; 257us; 258us; 265us; 270us; 281us; 287us; 288us; 293us; 294us; 295us; 296us; 299us; 302us; 308us; 313us; 318us; 323us; 328us; 337us; 339us; 340us; 341us; 343us; 344us; 347us; 349us; 350us; 353us; 356us; 357us; 359us; 360us; 362us; 363us; 364us; 365us; 367us; 368us; 373us; 378us; 380us; 381us; 382us; 390us; 391us; 392us; 393us; 399us; 401us; 407us; 409us; 410us; 415us; 417us; 423us; 425us; 426us; 431us; 433us; 434us; 439us; 441us; 442us; 443us; 444us; 445us; 447us; 448us; 449us; 450us; 452us; 455us; 464us; 465us; 466us; 467us; 468us; 471us; 473us; 476us; 477us; 479us; 481us; 482us; 484us; 485us; 486us; 488us; 489us; 491us; 494us; 495us; 497us; 507us; 508us; 510us; 520us; 521us; 522us; 524us; 526us; 527us; 529us; 531us; 532us; 533us; 535us; 538us; 542us; 544us; 545us; 547us; 548us; 550us; 551us; 553us; 555us; 557us; 558us; 560us; 562us; 564us; 565us; 567us; 568us; 570us; 572us; 574us; 575us; 576us; 579us; 582us; 583us; |]
+let _fsyacc_reductionSymbolCounts = [|1us; 1us; 2us; 1us; 3us; 1us; 2us; 1us; 1us; 1us; 1us; 3us; 1us; 1us; 1us; 1us; 1us; 1us; 1us; 2us; 1us; 2us; 1us; 1us; 2us; 3us; 4us; 5us; 5us; 5us; 5us; 5us; 5us; 1us; 3us; 8us; 7us; 1us; 1us; 1us; 1us; 1us; 1us; 3us; 1us; 4us; 3us; 1us; 3us; 1us; 1us; 1us; 3us; 2us; 3us; 3us; 3us; 3us; 3us; 1us; 1us; 3us; 4us; 5us; 4us; 1us; 1us; 2us; 1us; 2us; 2us; 1us; 1us; 2us; 1us; 1us; 2us; 5us; 6us; 6us; 7us; 1us; 1us; 1us; 2us; 1us; 2us; 1us; 3us; 1us; 1us; 1us; 1us; 3us; 1us; 3us; 3us; 1us; 2us; 3us; 1us; 3us; 1us; 3us; 1us; 1us; 3us; 3us; 1us; 0us; 3us; 3us; 2us; 4us; 1us; 4us; 2us; 3us; 1us; 4us; 1us; 1us; 2us; 1us; 2us; |]
+let _fsyacc_productionToNonTerminalTable = [|0us; 1us; 2us; 2us; 3us; 4us; 4us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 5us; 6us; 6us; 7us; 7us; 8us; 8us; 9us; 9us; 10us; 10us; 11us; 11us; 11us; 11us; 11us; 11us; 12us; 12us; 13us; 13us; 14us; 14us; 14us; 14us; 14us; 14us; 15us; 15us; 16us; 16us; 17us; 18us; 19us; 20us; 20us; 20us; 20us; 20us; 20us; 20us; 20us; 21us; 21us; 21us; 21us; 21us; 21us; 21us; 21us; 21us; 21us; 22us; 22us; 23us; 23us; 24us; 24us; 25us; 26us; 26us; 27us; 27us; 27us; 27us; 28us; 28us; 28us; 28us; 29us; 29us; 30us; 30us; 31us; 32us; 32us; 33us; 33us; 34us; 34us; 34us; 34us; 35us; 36us; 37us; 37us; 38us; 38us; 38us; 39us; 39us; 40us; 41us; 41us; 42us; 43us; 44us; 44us; 45us; 45us; 46us; 46us; 47us; 47us; 47us; 48us; 48us; 48us; 48us; |]
+let _fsyacc_immediateActions = [|65535us; 49152us; 16385us; 65535us; 16386us; 16387us; 65535us; 65535us; 16388us; 65535us; 16390us; 16391us; 16392us; 16393us; 16394us; 65535us; 65535us; 16395us; 16396us; 16397us; 16398us; 16399us; 16400us; 16401us; 16402us; 65535us; 16403us; 65535us; 16405us; 65535us; 16408us; 65535us; 65535us; 65535us; 16410us; 65535us; 65535us; 65535us; 65535us; 16411us; 65535us; 16412us; 65535us; 16413us; 65535us; 16414us; 65535us; 16415us; 65535us; 16416us; 65535us; 65535us; 16418us; 65535us; 65535us; 65535us; 65535us; 65535us; 16419us; 65535us; 65535us; 65535us; 16420us; 65535us; 65535us; 16423us; 16424us; 65535us; 16426us; 65535us; 65535us; 16427us; 65535us; 65535us; 65535us; 16429us; 16430us; 16431us; 65535us; 65535us; 16432us; 16433us; 16434us; 16435us; 65535us; 65535us; 65535us; 65535us; 16436us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 65535us; 16442us; 16443us; 65535us; 16444us; 65535us; 65535us; 16445us; 65535us; 65535us; 16446us; 65535us; 16447us; 65535us; 16448us; 16449us; 16450us; 65535us; 16451us; 65535us; 65535us; 65535us; 16454us; 16456us; 65535us; 16457us; 16458us; 16460us; 65535us; 65535us; 65535us; 65535us; 16461us; 65535us; 65535us; 65535us; 65535us; 16462us; 65535us; 65535us; 16463us; 65535us; 65535us; 16464us; 16465us; 16466us; 16467us; 65535us; 16468us; 16469us; 16470us; 65535us; 65535us; 65535us; 16472us; 16473us; 16474us; 16475us; 65535us; 65535us; 65535us; 16477us; 65535us; 65535us; 16479us; 65535us; 16480us; 16481us; 65535us; 16482us; 65535us; 65535us; 16483us; 65535us; 65535us; 16485us; 65535us; 65535us; 16487us; 16488us; 65535us; 65535us; 16490us; 65535us; 65535us; 16491us; 16492us; 65535us; 65535us; 65535us; 65535us; 16494us; 65535us; 16495us; 65535us; 16496us; 65535us; 65535us; 65535us; 16497us; 65535us; 65535us; 65535us; 16499us; 65535us; 16501us; 65535us; 65535us; 65535us; 16503us; 16504us; 65535us; 65535us; 16506us; 16508us; |]
 let _fsyacc_reductions ()  =    [| 
-# 526 "GslParser.fs"
+# 523 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : AstTreeHead)) in
             Microsoft.FSharp.Core.Operators.box
@@ -532,7 +529,7 @@ let _fsyacc_reductions ()  =    [|
                       raise (Microsoft.FSharp.Text.Parsing.Accept(Microsoft.FSharp.Core.Operators.box _1))
                    )
                  : '_startstart));
-# 535 "GslParser.fs"
+# 532 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Final)) in
             Microsoft.FSharp.Core.Operators.box
@@ -543,7 +540,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 59 "GslParser.fsy"
                  : AstTreeHead));
-# 546 "GslParser.fs"
+# 543 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'CodeSection)) in
             Microsoft.FSharp.Core.Operators.box
@@ -554,7 +551,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 62 "GslParser.fsy"
                  : 'Final));
-# 557 "GslParser.fs"
+# 554 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -564,7 +561,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 63 "GslParser.fsy"
                  : 'Final));
-# 567 "GslParser.fs"
+# 564 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'CodeSection)) in
             Microsoft.FSharp.Core.Operators.box
@@ -575,7 +572,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 66 "GslParser.fsy"
                  : 'ScopedBlock));
-# 578 "GslParser.fs"
+# 575 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Line)) in
             Microsoft.FSharp.Core.Operators.box
@@ -586,7 +583,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 69 "GslParser.fsy"
                  : 'CodeSection));
-# 589 "GslParser.fs"
+# 586 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Line)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'CodeSection)) in
@@ -598,7 +595,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 70 "GslParser.fsy"
                  : 'CodeSection));
-# 601 "GslParser.fs"
+# 598 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
@@ -608,7 +605,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 74 "GslParser.fsy"
                  : 'Line));
-# 611 "GslParser.fs"
+# 608 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'AssemblyPart)) in
             Microsoft.FSharp.Core.Operators.box
@@ -619,7 +616,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 75 "GslParser.fsy"
                  : 'Line));
-# 622 "GslParser.fs"
+# 619 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -630,7 +627,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 76 "GslParser.fsy"
                  : 'Line));
-# 633 "GslParser.fs"
+# 630 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2ExpLine)) in
             Microsoft.FSharp.Core.Operators.box
@@ -641,7 +638,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 77 "GslParser.fsy"
                  : 'Line));
-# 644 "GslParser.fs"
+# 641 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLineList)) in
             Microsoft.FSharp.Core.Operators.box
@@ -652,7 +649,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 78 "GslParser.fsy"
                  : 'Line));
-# 655 "GslParser.fs"
+# 652 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Pragma)) in
             Microsoft.FSharp.Core.Operators.box
@@ -663,7 +660,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 79 "GslParser.fsy"
                  : 'Line));
-# 666 "GslParser.fs"
+# 663 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'TypedVariableDeclaration)) in
             Microsoft.FSharp.Core.Operators.box
@@ -674,7 +671,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 80 "GslParser.fsy"
                  : 'Line));
-# 677 "GslParser.fs"
+# 674 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'FunctionCall)) in
             Microsoft.FSharp.Core.Operators.box
@@ -685,7 +682,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 81 "GslParser.fsy"
                  : 'Line));
-# 688 "GslParser.fs"
+# 685 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'FunctionDeclaration)) in
             Microsoft.FSharp.Core.Operators.box
@@ -696,7 +693,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 82 "GslParser.fsy"
                  : 'Line));
-# 699 "GslParser.fs"
+# 696 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'ScopedBlock)) in
             Microsoft.FSharp.Core.Operators.box
@@ -707,7 +704,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 83 "GslParser.fsy"
                  : 'Line));
-# 710 "GslParser.fs"
+# 707 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -718,7 +715,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 93 "GslParser.fsy"
                  : 'PragmaValue));
-# 721 "GslParser.fs"
+# 718 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -729,7 +726,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 94 "GslParser.fsy"
                  : 'PragmaValue));
-# 732 "GslParser.fs"
+# 729 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PragmaValue)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'PragmaValues)) in
@@ -741,7 +738,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 97 "GslParser.fsy"
                  : 'PragmaValues));
-# 744 "GslParser.fs"
+# 741 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PragmaValue)) in
             Microsoft.FSharp.Core.Operators.box
@@ -752,7 +749,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 98 "GslParser.fsy"
                  : 'PragmaValues));
-# 755 "GslParser.fs"
+# 752 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'PragmaValues)) in
@@ -764,7 +761,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 101 "GslParser.fsy"
                  : 'Pragma));
-# 767 "GslParser.fs"
+# 764 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -775,7 +772,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 102 "GslParser.fsy"
                  : 'Pragma));
-# 778 "GslParser.fs"
+# 775 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Pragma)) in
             Microsoft.FSharp.Core.Operators.box
@@ -786,7 +783,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 105 "GslParser.fsy"
                  : 'Pragmas));
-# 789 "GslParser.fs"
+# 786 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Pragma)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'Pragmas)) in
@@ -798,7 +795,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 106 "GslParser.fsy"
                  : 'Pragmas));
-# 801 "GslParser.fs"
+# 798 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'Pragmas)) in
             Microsoft.FSharp.Core.Operators.box
@@ -809,7 +806,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 109 "GslParser.fsy"
                  : 'InlinePragmas));
-# 812 "GslParser.fs"
+# 809 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'Pragmas)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'InlinePragmas)) in
@@ -821,7 +818,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 110 "GslParser.fsy"
                  : 'InlinePragmas));
-# 824 "GslParser.fs"
+# 821 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
@@ -833,7 +830,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 119 "GslParser.fsy"
                  : 'TypedVariableDeclaration));
-# 836 "GslParser.fs"
+# 833 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
@@ -845,7 +842,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 120 "GslParser.fsy"
                  : 'TypedVariableDeclaration));
-# 848 "GslParser.fs"
+# 845 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'StringLiteral)) in
@@ -857,7 +854,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 121 "GslParser.fsy"
                  : 'TypedVariableDeclaration));
-# 860 "GslParser.fs"
+# 857 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'FloatLiteral)) in
@@ -869,7 +866,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 122 "GslParser.fsy"
                  : 'TypedVariableDeclaration));
-# 872 "GslParser.fs"
+# 869 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'CompletePart)) in
@@ -881,7 +878,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 123 "GslParser.fsy"
                  : 'TypedVariableDeclaration));
-# 884 "GslParser.fs"
+# 881 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'AssemblyPart)) in
@@ -893,7 +890,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 124 "GslParser.fsy"
                  : 'TypedVariableDeclaration));
-# 896 "GslParser.fs"
+# 893 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -904,7 +901,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 132 "GslParser.fsy"
                  : 'FunctionDefArgs));
-# 907 "GslParser.fs"
+# 904 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'FunctionDefArgs)) in
@@ -916,7 +913,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 133 "GslParser.fsy"
                  : 'FunctionDefArgs));
-# 919 "GslParser.fs"
+# 916 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'FunctionDefArgs)) in
@@ -929,7 +926,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 136 "GslParser.fsy"
                  : 'FunctionDeclaration));
-# 932 "GslParser.fs"
+# 929 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _6 = (let data = parseState.GetInput(6) in (Microsoft.FSharp.Core.Operators.unbox data : 'CodeSection)) in
@@ -941,7 +938,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 137 "GslParser.fsy"
                  : 'FunctionDeclaration));
-# 944 "GslParser.fs"
+# 941 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -952,7 +949,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 145 "GslParser.fsy"
                  : 'TypedValue));
-# 955 "GslParser.fs"
+# 952 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             Microsoft.FSharp.Core.Operators.box
@@ -963,7 +960,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 146 "GslParser.fsy"
                  : 'TypedValue));
-# 966 "GslParser.fs"
+# 963 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'StringLiteral)) in
             Microsoft.FSharp.Core.Operators.box
@@ -974,7 +971,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 147 "GslParser.fsy"
                  : 'TypedValue));
-# 977 "GslParser.fs"
+# 974 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'FloatLiteral)) in
             Microsoft.FSharp.Core.Operators.box
@@ -985,7 +982,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 148 "GslParser.fsy"
                  : 'TypedValue));
-# 988 "GslParser.fs"
+# 985 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'CompletePart)) in
             Microsoft.FSharp.Core.Operators.box
@@ -996,7 +993,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 149 "GslParser.fsy"
                  : 'TypedValue));
-# 999 "GslParser.fs"
+# 996 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'AssemblyPart)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1007,7 +1004,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 150 "GslParser.fsy"
                  : 'TypedValue));
-# 1010 "GslParser.fs"
+# 1007 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'TypedValue)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'CommaSeparatedTypedValues)) in
@@ -1019,7 +1016,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 154 "GslParser.fsy"
                  : 'CommaSeparatedTypedValues));
-# 1022 "GslParser.fs"
+# 1019 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'TypedValue)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1030,7 +1027,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 155 "GslParser.fsy"
                  : 'CommaSeparatedTypedValues));
-# 1033 "GslParser.fs"
+# 1030 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'CommaSeparatedTypedValues)) in
@@ -1042,7 +1039,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 158 "GslParser.fsy"
                  : 'FunctionCall));
-# 1045 "GslParser.fs"
+# 1042 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1053,7 +1050,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 159 "GslParser.fsy"
                  : 'FunctionCall));
-# 1056 "GslParser.fs"
+# 1053 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PInt)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1064,7 +1061,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 167 "GslParser.fsy"
                  : 'IntLiteral));
-# 1067 "GslParser.fs"
+# 1064 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PInt)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PInt)) in
@@ -1076,7 +1073,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 170 "GslParser.fsy"
                  : 'FloatLiteral));
-# 1079 "GslParser.fs"
+# 1076 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1087,7 +1084,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 173 "GslParser.fsy"
                  : 'StringLiteral));
-# 1090 "GslParser.fs"
+# 1087 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntLiteral)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1098,7 +1095,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 180 "GslParser.fsy"
                  : 'IntExp));
-# 1101 "GslParser.fs"
+# 1098 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1109,7 +1106,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 181 "GslParser.fsy"
                  : 'IntExp));
-# 1112 "GslParser.fs"
+# 1109 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1120,7 +1117,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 182 "GslParser.fsy"
                  : 'IntExp));
-# 1123 "GslParser.fs"
+# 1120 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             Microsoft.FSharp.Core.Operators.box
@@ -1131,7 +1128,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 183 "GslParser.fsy"
                  : 'IntExp));
-# 1134 "GslParser.fs"
+# 1131 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
@@ -1143,7 +1140,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 184 "GslParser.fsy"
                  : 'IntExp));
-# 1146 "GslParser.fs"
+# 1143 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
@@ -1155,7 +1152,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 185 "GslParser.fsy"
                  : 'IntExp));
-# 1158 "GslParser.fs"
+# 1155 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
@@ -1167,7 +1164,7 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 186 "GslParser.fsy"
                  : 'IntExp));
-# 1170 "GslParser.fs"
+# 1167 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
@@ -1179,256 +1176,230 @@ let _fsyacc_reductions ()  =    [|
                    )
 # 187 "GslParser.fsy"
                  : 'IntExp));
-# 1182 "GslParser.fs"
-        (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
-            let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
-            Microsoft.FSharp.Core.Operators.box
-                (
-                   (
-# 194 "GslParser.fsy"
-                                       match _1.i.Split([| '-' |]) with
-                                       | [| a;b;c |] -> {l1 = a ; l2 = b; orient = c}
-                                       | _ -> failwithf "bad linker format '%s'" (_1.i)
-                                     
-                   )
-# 194 "GslParser.fsy"
-                 : 'Linker));
-# 1196 "GslParser.fs"
+# 1179 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'AssemblyPart)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 200 "GslParser.fsy"
+# 194 "GslParser.fsy"
                                                            _2 
                    )
-# 200 "GslParser.fsy"
+# 194 "GslParser.fsy"
                  : 'Part));
-# 1207 "GslParser.fs"
-        (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
-            let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Linker)) in
-            let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
-            Microsoft.FSharp.Core.Operators.box
-                (
-                   (
-# 202 "GslParser.fsy"
-                                                           createGenePart _3 (Some(_1)) 
-                   )
-# 202 "GslParser.fsy"
-                 : 'Part));
-# 1219 "GslParser.fs"
+# 1190 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 204 "GslParser.fsy"
-                                                           createGenePart _1 None 
+# 196 "GslParser.fsy"
+                                                           createPartWithBase (Gene(tokenAsNode _1)) 
                    )
-# 204 "GslParser.fsy"
+# 196 "GslParser.fsy"
                  : 'Part));
-# 1230 "GslParser.fs"
+# 1201 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 205 "GslParser.fsy"
+# 197 "GslParser.fsy"
                                                            createPartWithBase (Marker(tokenAsNode _1)) 
                    )
-# 205 "GslParser.fsy"
+# 197 "GslParser.fsy"
                  : 'Part));
-# 1241 "GslParser.fs"
+# 1212 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 207 "GslParser.fsy"
+# 199 "GslParser.fsy"
                                                            createPartWithBase (InlineDna(tokenAsNodeAfter uppercase _2)) 
                    )
-# 207 "GslParser.fsy"
+# 199 "GslParser.fsy"
                  : 'Part));
-# 1252 "GslParser.fs"
+# 1223 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 209 "GslParser.fsy"
+# 201 "GslParser.fsy"
                                                            createPartWithBase (InlineProtein(tokenAsNodeAfter uppercase _3))
                    )
-# 209 "GslParser.fsy"
+# 201 "GslParser.fsy"
                  : 'Part));
-# 1263 "GslParser.fs"
+# 1234 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 211 "GslParser.fsy"
+# 203 "GslParser.fsy"
                                                            createPartWithBase (InlineProtein(tokenAsNodeAfter (fun s -> (s |> uppercase, "*") ||> (+) ) _3 )) 
                    )
-# 211 "GslParser.fsy"
+# 203 "GslParser.fsy"
                  : 'Part));
-# 1274 "GslParser.fs"
+# 1245 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 213 "GslParser.fsy"
+# 205 "GslParser.fsy"
                                                            createPartWithBase (InlineProtein(nodeWrap "*")) 
                    )
-# 213 "GslParser.fsy"
+# 205 "GslParser.fsy"
                  : 'Part));
-# 1284 "GslParser.fs"
+# 1255 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 214 "GslParser.fsy"
+# 206 "GslParser.fsy"
                                                            createPartWithBase (HetBlock(tokenAsNode _1)) 
                    )
-# 214 "GslParser.fsy"
+# 206 "GslParser.fsy"
                  : 'Part));
-# 1295 "GslParser.fs"
+# 1266 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 216 "GslParser.fsy"
+# 208 "GslParser.fsy"
                                                            createPartWithBase (tokenToVariable _1 PartType) 
                    )
-# 216 "GslParser.fsy"
+# 208 "GslParser.fsy"
                  : 'Part));
-# 1306 "GslParser.fs"
+# 1277 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 218 "GslParser.fsy"
+# 210 "GslParser.fsy"
                                                            createPartWithBase (PartId(tokenAsNode _2)) 
                    )
-# 218 "GslParser.fsy"
+# 210 "GslParser.fsy"
                  : 'Part));
-# 1317 "GslParser.fs"
+# 1288 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Part)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 222 "GslParser.fsy"
+# 214 "GslParser.fsy"
                                            _1 
                    )
-# 222 "GslParser.fsy"
+# 214 "GslParser.fsy"
                  : 'PartMaybeMods));
-# 1328 "GslParser.fs"
+# 1299 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Part)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'ModList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 223 "GslParser.fsy"
+# 215 "GslParser.fsy"
                                            stuffModsIntoPart _1 _2 
                    )
-# 223 "GslParser.fsy"
+# 215 "GslParser.fsy"
                  : 'PartMaybeMods));
-# 1340 "GslParser.fs"
+# 1311 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PartMaybeMods)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'InlinePragmas)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 228 "GslParser.fsy"
+# 220 "GslParser.fsy"
                                                                stuffPragmasIntoPart _1 _2 
                    )
-# 228 "GslParser.fsy"
+# 220 "GslParser.fsy"
                  : 'PartMaybePragma));
-# 1352 "GslParser.fs"
+# 1323 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PartMaybeMods)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 229 "GslParser.fsy"
+# 221 "GslParser.fsy"
                                                                _1 
                    )
-# 229 "GslParser.fsy"
+# 221 "GslParser.fsy"
                  : 'PartMaybePragma));
-# 1363 "GslParser.fs"
+# 1334 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PartMaybePragma)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 233 "GslParser.fsy"
+# 225 "GslParser.fsy"
                                              _1 
                    )
-# 233 "GslParser.fsy"
+# 225 "GslParser.fsy"
                  : 'PartFwdRev));
-# 1374 "GslParser.fs"
+# 1345 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'PartMaybePragma)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 234 "GslParser.fsy"
+# 226 "GslParser.fsy"
                                                    revPart _2 
                    )
-# 234 "GslParser.fsy"
+# 226 "GslParser.fsy"
                  : 'PartFwdRev));
-# 1385 "GslParser.fs"
+# 1356 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PartFwdRev)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 238 "GslParser.fsy"
+# 230 "GslParser.fsy"
                                        _1
                    )
-# 238 "GslParser.fsy"
+# 230 "GslParser.fsy"
                  : 'CompletePart));
-# 1396 "GslParser.fs"
+# 1367 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 245 "GslParser.fsy"
+# 237 "GslParser.fsy"
                                          (_1, None) 
                    )
-# 245 "GslParser.fsy"
+# 237 "GslParser.fsy"
                  : 'RelPos));
-# 1407 "GslParser.fs"
+# 1378 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'IntExp)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 246 "GslParser.fsy"
+# 238 "GslParser.fsy"
                                          (_1, (Some _2)) 
                    )
-# 246 "GslParser.fsy"
+# 238 "GslParser.fsy"
                  : 'RelPos));
-# 1419 "GslParser.fs"
+# 1390 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'RelPos)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'RelPos)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 249 "GslParser.fsy"
+# 241 "GslParser.fsy"
                                                                                              createParseSlice _2 _4 false false 
                    )
-# 249 "GslParser.fsy"
+# 241 "GslParser.fsy"
                  : 'Slice));
-# 1431 "GslParser.fs"
+# 1402 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'RelPos)) in
@@ -1436,12 +1407,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 250 "GslParser.fsy"
+# 242 "GslParser.fsy"
                                                                                              createParseSlice _3 _5 true false 
                    )
-# 250 "GslParser.fsy"
+# 242 "GslParser.fsy"
                  : 'Slice));
-# 1444 "GslParser.fs"
+# 1415 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'RelPos)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
@@ -1449,12 +1420,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 251 "GslParser.fsy"
+# 243 "GslParser.fsy"
                                                                                              createParseSlice _2 _5 false true 
                    )
-# 251 "GslParser.fsy"
+# 243 "GslParser.fsy"
                  : 'Slice));
-# 1457 "GslParser.fs"
+# 1428 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'RelPos)) in
@@ -1463,90 +1434,90 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 252 "GslParser.fsy"
+# 244 "GslParser.fsy"
                                                                                              createParseSlice _3 _6 true true 
                    )
-# 252 "GslParser.fsy"
+# 244 "GslParser.fsy"
                  : 'Slice));
-# 1471 "GslParser.fs"
+# 1442 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 255 "GslParser.fsy"
+# 247 "GslParser.fsy"
                                             createMutation _1 NT 
                    )
-# 255 "GslParser.fsy"
+# 247 "GslParser.fsy"
                  : 'Mod));
-# 1482 "GslParser.fs"
+# 1453 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 256 "GslParser.fsy"
+# 248 "GslParser.fsy"
                                             createMutation _1 AA 
                    )
-# 256 "GslParser.fsy"
+# 248 "GslParser.fsy"
                  : 'Mod));
-# 1493 "GslParser.fs"
+# 1464 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Slice)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 257 "GslParser.fsy"
+# 249 "GslParser.fsy"
                                             _1 
                    )
-# 257 "GslParser.fsy"
+# 249 "GslParser.fsy"
                  : 'Mod));
-# 1504 "GslParser.fs"
+# 1475 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 258 "GslParser.fsy"
+# 250 "GslParser.fsy"
                                          DotMod(tokenAsNode _2) 
                    )
-# 258 "GslParser.fsy"
+# 250 "GslParser.fsy"
                  : 'Mod));
-# 1515 "GslParser.fs"
+# 1486 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'Mod)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 261 "GslParser.fsy"
+# 253 "GslParser.fsy"
                                                            [ _1 ] 
                    )
-# 261 "GslParser.fsy"
+# 253 "GslParser.fsy"
                  : 'ModList));
-# 1526 "GslParser.fs"
+# 1497 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'ModList)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'Mod)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 262 "GslParser.fsy"
+# 254 "GslParser.fsy"
                                                            _2 :: _1 
                    )
-# 262 "GslParser.fsy"
+# 254 "GslParser.fsy"
                  : 'ModList));
-# 1538 "GslParser.fs"
+# 1509 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'CompletePart)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 269 "GslParser.fsy"
+# 261 "GslParser.fsy"
                                                                    [_1] 
                    )
-# 269 "GslParser.fsy"
+# 261 "GslParser.fsy"
                  : 'PartList));
-# 1549 "GslParser.fs"
+# 1520 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'CompletePart)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
@@ -1554,148 +1525,148 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 270 "GslParser.fsy"
+# 262 "GslParser.fsy"
                                                                    _1::_3 
                    )
-# 270 "GslParser.fsy"
+# 262 "GslParser.fsy"
                  : 'PartList));
-# 1562 "GslParser.fs"
+# 1533 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'PartList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 275 "GslParser.fsy"
+# 267 "GslParser.fsy"
                                            createAssemblyPart _1 
                    )
-# 275 "GslParser.fsy"
+# 267 "GslParser.fsy"
                  : 'AssemblyPart));
-# 1573 "GslParser.fs"
+# 1544 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 285 "GslParser.fsy"
+# 277 "GslParser.fsy"
                                      tokenAsNode _1 
                    )
-# 285 "GslParser.fsy"
+# 277 "GslParser.fsy"
                  : 'L2IdWrap));
-# 1584 "GslParser.fs"
+# 1555 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 286 "GslParser.fsy"
+# 278 "GslParser.fsy"
                                      tokenAsNode _1 
                    )
-# 286 "GslParser.fsy"
+# 278 "GslParser.fsy"
                  : 'L2IdWrap));
-# 1595 "GslParser.fs"
+# 1566 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2IdWrap)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 296 "GslParser.fsy"
+# 288 "GslParser.fsy"
                                            createL2Id None _1 
                    )
-# 296 "GslParser.fsy"
+# 288 "GslParser.fsy"
                  : 'L2Id));
-# 1606 "GslParser.fs"
+# 1577 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2IdWrap)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2IdWrap)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 297 "GslParser.fsy"
+# 289 "GslParser.fsy"
                                                     createL2Id (Some(_1)) _3 
                    )
-# 297 "GslParser.fsy"
+# 289 "GslParser.fsy"
                  : 'L2Id));
-# 1618 "GslParser.fs"
+# 1589 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 301 "GslParser.fsy"
+# 293 "GslParser.fsy"
                                       createL2Id None (tokenAsNode _1) 
                    )
-# 301 "GslParser.fsy"
+# 293 "GslParser.fsy"
                  : 'L2Promoter));
-# 1629 "GslParser.fs"
+# 1600 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 302 "GslParser.fsy"
+# 294 "GslParser.fsy"
                                                 createL2Id (Some(tokenAsNode _1)) (tokenAsNode _3) 
                    )
-# 302 "GslParser.fsy"
+# 294 "GslParser.fsy"
                  : 'L2Promoter));
-# 1641 "GslParser.fs"
+# 1612 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 303 "GslParser.fsy"
+# 295 "GslParser.fsy"
                                                 createL2Id (Some(tokenAsNode _1)) (tokenAsNode _3) 
                    )
-# 303 "GslParser.fsy"
+# 295 "GslParser.fsy"
                  : 'L2Promoter));
-# 1653 "GslParser.fs"
+# 1624 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'CompletePart)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 304 "GslParser.fsy"
+# 296 "GslParser.fsy"
                                           _1 
                    )
-# 304 "GslParser.fsy"
+# 296 "GslParser.fsy"
                  : 'L2Promoter));
-# 1664 "GslParser.fs"
+# 1635 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2Id)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 309 "GslParser.fsy"
+# 301 "GslParser.fsy"
                                           _1 
                    )
-# 309 "GslParser.fsy"
+# 301 "GslParser.fsy"
                  : 'L2Locus));
-# 1675 "GslParser.fs"
+# 1646 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2Promoter)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2Id)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 313 "GslParser.fsy"
+# 305 "GslParser.fsy"
                                                           createL2Element _1 _3 
                    )
-# 313 "GslParser.fsy"
+# 305 "GslParser.fsy"
                  : 'L2ExpElement));
-# 1687 "GslParser.fs"
+# 1658 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2ExpElement)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 317 "GslParser.fsy"
+# 309 "GslParser.fsy"
                                           [_1] 
                    )
-# 317 "GslParser.fsy"
+# 309 "GslParser.fsy"
                  : 'L2ExpElementList));
-# 1698 "GslParser.fs"
+# 1669 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2ExpElement)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
@@ -1703,23 +1674,23 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 318 "GslParser.fsy"
+# 310 "GslParser.fsy"
                                                                      _1::_3 
                    )
-# 318 "GslParser.fsy"
+# 310 "GslParser.fsy"
                  : 'L2ExpElementList));
-# 1711 "GslParser.fs"
+# 1682 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2Locus)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 322 "GslParser.fsy"
+# 314 "GslParser.fsy"
                                                   createL2Expression (Some(_1)) [] 
                    )
-# 322 "GslParser.fsy"
+# 314 "GslParser.fsy"
                  : 'L2ExpLine));
-# 1722 "GslParser.fs"
+# 1693 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2Locus)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PUnit)) in
@@ -1727,114 +1698,114 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 323 "GslParser.fsy"
+# 315 "GslParser.fsy"
                                                                  createL2Expression (Some(_1)) _3 
                    )
-# 323 "GslParser.fsy"
+# 315 "GslParser.fsy"
                  : 'L2ExpLine));
-# 1735 "GslParser.fs"
+# 1706 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'L2ExpElementList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 324 "GslParser.fsy"
+# 316 "GslParser.fsy"
                                                     createL2Expression None _1 
                    )
-# 324 "GslParser.fsy"
+# 316 "GslParser.fsy"
                  : 'L2ExpLine));
-# 1746 "GslParser.fs"
+# 1717 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 332 "GslParser.fsy"
+# 324 "GslParser.fsy"
                                  createL2IdNode None (tokenAsNode _1) 
                    )
-# 332 "GslParser.fsy"
+# 324 "GslParser.fsy"
                  : 'RID));
-# 1757 "GslParser.fs"
+# 1728 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 333 "GslParser.fsy"
+# 325 "GslParser.fsy"
                                        createL2IdNode (Some(tokenAsNode _1)) (tokenAsNode _3) 
                    )
-# 333 "GslParser.fsy"
+# 325 "GslParser.fsy"
                  : 'RID));
-# 1769 "GslParser.fs"
+# 1740 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : PString)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 336 "GslParser.fsy"
+# 328 "GslParser.fsy"
                                                           tokenAsNode _2 
                    )
-# 336 "GslParser.fsy"
+# 328 "GslParser.fsy"
                  : 'RoughageMarker));
-# 1780 "GslParser.fs"
+# 1751 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageMarker)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 340 "GslParser.fsy"
+# 332 "GslParser.fsy"
                                             Some(_1) 
                    )
-# 340 "GslParser.fsy"
+# 332 "GslParser.fsy"
                  : 'RoughageMarkerMaybe));
-# 1791 "GslParser.fs"
+# 1762 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 341 "GslParser.fsy"
+# 333 "GslParser.fsy"
                              None 
                    )
-# 341 "GslParser.fsy"
+# 333 "GslParser.fsy"
                  : 'RoughageMarkerMaybe));
-# 1801 "GslParser.fs"
+# 1772 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RID)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'RID)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 344 "GslParser.fsy"
+# 336 "GslParser.fsy"
                                                createRoughagePart RoughageFwd _1 _3 
                    )
-# 344 "GslParser.fsy"
+# 336 "GslParser.fsy"
                  : 'RoughagePartFwd));
-# 1813 "GslParser.fs"
+# 1784 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RID)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'RID)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 347 "GslParser.fsy"
+# 339 "GslParser.fsy"
                                             createRoughagePart RoughageRev _3 _1 
                    )
-# 347 "GslParser.fsy"
+# 339 "GslParser.fsy"
                  : 'RoughagePartRev));
-# 1825 "GslParser.fs"
+# 1796 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughagePartFwd)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageMarkerMaybe)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 352 "GslParser.fsy"
+# 344 "GslParser.fsy"
                                                                  createRoughageElement _1 None _2 
                    )
-# 352 "GslParser.fsy"
+# 344 "GslParser.fsy"
                  : 'RoughageElement));
-# 1837 "GslParser.fs"
+# 1808 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughagePartRev)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughagePartFwd)) in
@@ -1842,137 +1813,137 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 354 "GslParser.fsy"
+# 346 "GslParser.fsy"
                                                                                         createRoughageElement _1 (Some(_3)) _4 
                    )
-# 354 "GslParser.fsy"
+# 346 "GslParser.fsy"
                  : 'RoughageElement));
-# 1850 "GslParser.fs"
+# 1821 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageElement)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 357 "GslParser.fsy"
+# 349 "GslParser.fsy"
                                              [_1] 
                    )
-# 357 "GslParser.fsy"
+# 349 "GslParser.fsy"
                  : 'RoughageElementList));
-# 1861 "GslParser.fs"
+# 1832 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageElement)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageElementList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 358 "GslParser.fsy"
+# 350 "GslParser.fsy"
                                                                              _1::_4 
                    )
-# 358 "GslParser.fsy"
+# 350 "GslParser.fsy"
                  : 'RoughageElementList));
-# 1873 "GslParser.fs"
+# 1844 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RID)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 362 "GslParser.fsy"
+# 354 "GslParser.fsy"
                                          (Some(_1), None) 
                    )
-# 362 "GslParser.fsy"
+# 354 "GslParser.fsy"
                  : 'RoughageLocus));
-# 1884 "GslParser.fs"
+# 1855 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RID)) in
             let _3 = (let data = parseState.GetInput(3) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageMarker)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 363 "GslParser.fsy"
+# 355 "GslParser.fsy"
                                                       (Some(_1), Some(_3)) 
                    )
-# 363 "GslParser.fsy"
+# 355 "GslParser.fsy"
                  : 'RoughageLocus));
-# 1896 "GslParser.fs"
+# 1867 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLocus)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 366 "GslParser.fsy"
+# 358 "GslParser.fsy"
                                                   createRoughageLine _1 [] 
                    )
-# 366 "GslParser.fsy"
+# 358 "GslParser.fsy"
                  : 'RoughageLine));
-# 1907 "GslParser.fs"
+# 1878 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLocus)) in
             let _4 = (let data = parseState.GetInput(4) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageElementList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 367 "GslParser.fsy"
+# 359 "GslParser.fsy"
                                                                             createRoughageLine _1 _4 
                    )
-# 367 "GslParser.fsy"
+# 359 "GslParser.fsy"
                  : 'RoughageLine));
-# 1919 "GslParser.fs"
+# 1890 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageElementList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 368 "GslParser.fsy"
+# 360 "GslParser.fsy"
                                                   createRoughageLine (None, None) _1 
                    )
-# 368 "GslParser.fsy"
+# 360 "GslParser.fsy"
                  : 'RoughageLine));
-# 1930 "GslParser.fs"
+# 1901 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLine)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 371 "GslParser.fsy"
+# 363 "GslParser.fsy"
                                                              [_1] 
                    )
-# 371 "GslParser.fsy"
+# 363 "GslParser.fsy"
                  : 'RoughageLineList));
-# 1941 "GslParser.fs"
+# 1912 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLineList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 372 "GslParser.fsy"
+# 364 "GslParser.fsy"
                                                              _2 
                    )
-# 372 "GslParser.fsy"
+# 364 "GslParser.fsy"
                  : 'RoughageLineList));
-# 1952 "GslParser.fs"
+# 1923 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 373 "GslParser.fsy"
+# 365 "GslParser.fsy"
                                                              [] 
                    )
-# 373 "GslParser.fsy"
+# 365 "GslParser.fsy"
                  : 'RoughageLineList));
-# 1962 "GslParser.fs"
+# 1933 "GslParser.fs"
         (fun (parseState : Microsoft.FSharp.Text.Parsing.IParseState) ->
             let _1 = (let data = parseState.GetInput(1) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLine)) in
             let _2 = (let data = parseState.GetInput(2) in (Microsoft.FSharp.Core.Operators.unbox data : 'RoughageLineList)) in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 374 "GslParser.fsy"
+# 366 "GslParser.fsy"
                                                              _1::_2 
                    )
-# 374 "GslParser.fsy"
+# 366 "GslParser.fsy"
                  : 'RoughageLineList));
 |]
-# 1975 "GslParser.fs"
+# 1946 "GslParser.fs"
 let tables () : Microsoft.FSharp.Text.Parsing.Tables<_> = 
   { reductions= _fsyacc_reductions ();
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/src/GslCore/GslParser.fsi
+++ b/src/GslCore/GslParser.fsi
@@ -120,7 +120,6 @@ type nonTerminalId =
     | NONTERM_FloatLiteral
     | NONTERM_StringLiteral
     | NONTERM_IntExp
-    | NONTERM_Linker
     | NONTERM_Part
     | NONTERM_PartMaybeMods
     | NONTERM_PartMaybePragma

--- a/src/GslCore/GslParser.fsy
+++ b/src/GslCore/GslParser.fsy
@@ -190,18 +190,10 @@ IntExp:
 // parts
 // ==================
 
-// FIXME: should push this to the AST
-Linker: LINKER  { match $1.i.Split([| '-' |]) with
-                  | [| a;b;c |] -> {l1 = a ; l2 = b; orient = c}
-                  | _ -> failwithf "bad linker format '%s'" ($1.i)
-                }
-
 Part:
     | LPAREN AssemblyPart RPAREN    { $2 }
-    // gene part with a linker
-    | Linker HYPHEN ID              { createGenePart $3 (Some($1)) }
-    // gene part without a linker
-    | ID                            { createGenePart $1 None }
+    // gene part
+    | ID                            { createPartWithBase (Gene(tokenAsNode $1)) }
     | MARKER                        { createPartWithBase (Marker(tokenAsNode $1)) }
     // Inline DNA sequence  / gatca /
     | SLASH ID SLASH                { createPartWithBase (InlineDna(tokenAsNodeAfter uppercase $2)) }

--- a/src/GslCore/Ryse.fs
+++ b/src/GslCore/Ryse.fs
@@ -44,13 +44,6 @@ let extractLinker (s:string ) =
     if s.StartsWith("Linker_") then s.[7..]
     else failwithf "ERROR: unable to parse linker name '%s'" s
 
-let checkLinker (l:Linker) =
-    if not (legalLinkers.Contains(l.l1)) then
-        failwithf "ERROR: linker %s not a legal linker" l.l1
-    if not (legalLinkers.Contains(l.l2)) then
-        failwithf "ERROR: linker %s not a legal linker" l.l2
-
-
 /// Get auxillary cached information about key rabits for thumper rabits
 let loadThumperRef (f:string) =
     if not (File.Exists f) then

--- a/tests/GslCore.Tests/AstFixtures.fs
+++ b/tests/GslCore.Tests/AstFixtures.fs
@@ -53,8 +53,8 @@ let fooEqual1 = variableize "foo" (wrapInt 1)
 
 let namePragmaFoo = ParsePragma(nodeWrap {name = "name"; values = [String(nodeWrap "foo")]})
 
+let createGenePart name = nodeWrap name |> Gene
 
-let createGenePart name = Gene(nodeWrap {gene = name; linker = None})
 // fixtures and helper functions for parts
 let fooGene = createGenePart "gFOO"
 


### PR DESCRIPTION
Removes the 0-5-0-gFOO syntax for specifying linkers at the part level, as well as some type-level cruft that comes along for the ride.