### PR TITLE
19/05/FEA: #topology - 2

### DIFF
--- a/src/GslCore/Ape.fs
+++ b/src/GslCore/Ape.fs
@@ -8,6 +8,12 @@ open Amyris.Bio.utils
 open utils
 open Amyris.Dna
 open Genbank
+open pragmaTypes
+        
+let topologyToString : Topology -> string =
+    function
+    | Linear -> "linear"
+    | Circular -> "circular" 
         
 /// Emit APE (genbank) format
 ///  outDir : string   tag: string  prefix for files  assemblies : List of AssemblyOut
@@ -22,7 +28,8 @@ let dumpAPE (outDir:string) (tag:string) (assemblies : DnaAssembly list) =
         let locusName = sprintf "%s_ape_output" tag
         let totLength = a.dnaParts |> List.map (fun p -> p.dna.Length) |> Seq.sum
         let now = DateTime.Now
-        sprintf "LOCUS                 %15s%5d bp ds-DNA   linear       %2d-%s-%d
+        let topology = a.topology |> topologyToString
+        sprintf "LOCUS                 %15s%5d bp ds-DNA   %s       %2d-%s-%d
 DEFINITION  .
 ACCESSION
 VERSION
@@ -31,7 +38,7 @@ SOURCE      .
 COMMENT
 COMMENT     ApEinfo:methylated:1
 FEATURES             Location/Qualifiers
-"           locusName totLength now.Day (mon.[now.Month-1]) now.Year |> w
+"           locusName totLength topology now.Day (mon.[now.Month-1]) now.Year |> w
         for p in a.dnaParts do
             let colorFwd = match p.sliceType with | REGULAR -> "#0000FF" | LINKER -> "#FF0000"
                                                   | MARKER -> "yellow" | INLINEST -> "green" | FUSIONST -> "red"

--- a/src/GslCore/CommonTypes.fs
+++ b/src/GslCore/CommonTypes.fs
@@ -210,16 +210,17 @@ let recalcOffset (pieces: DNASlice list) =
         {p with destFr = o; destTo = o+(p.dna.Length-1)*1<ZeroOffset> } )
 
 type DnaAssembly =
-   {id: int option;
-    dnaParts: DNASlice list;
-    name: string;
-    uri: Uri option;
-    linkerHint: string;
-    pragmas: PragmaCollection;
-    designParams: DesignParams;
-    docStrings: string list;
-    materializedFrom: Assembly}
-    with
+   { id : int option
+     dnaParts : DNASlice list
+     name : string
+     uri : Uri option
+     linkerHint : string
+     pragmas : PragmaCollection
+     designParams : DesignParams
+     docStrings : string list
+     materializedFrom : Assembly
+     topology : Topology }
+with
     member x.Sequence() =
         x.dnaParts
         |> Seq.map (fun p -> p.dna)

--- a/src/GslCore/Snapgene.fs
+++ b/src/GslCore/Snapgene.fs
@@ -4,10 +4,16 @@ open System.IO
 open System
 open commonTypes
 open constants
+open pragmaTypes
 open Amyris.Bio.utils
 open utils
 open Amyris.Dna
 open Genbank
+        
+let topologyToString : Topology -> string =
+    function
+    | Linear -> "linear"
+    | Circular -> "circular"
         
 /// Emit Snapgene (genbank) format
 ///  outDir : string   tag: string  prefix for files  assemblies : List of AssemblyOut
@@ -37,6 +43,7 @@ let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (p
         let locusName = sprintf "Exported GSL %s" tag
         let totLength = a.dnaParts |> List.map (fun p -> p.dna.Length) |> Seq.sum
         let now = DateTime.Now
+        let topology = a.topology |> topologyToString
         (* // constraints on header format per SnapGene direct correspandance
 
         1) LOCUS must contain "Exported".
@@ -46,7 +53,7 @@ let dumpSnapgene (outDir:string) (tag:string) (assemblies : DnaAssembly list) (p
             but we recently relaxed that requirement. The change is in version 4.1.)
         *)
 
-        sprintf "LOCUS       %-22s %d bp ds-DNA     linear   SYN %2d-%s-%d
+        sprintf "LOCUS       %-22s %d bp ds-DNA     %s   SYN %2d-%s-%d
 DEFINITION  .
 ACCESSION   .
 VERSION     .
@@ -67,6 +74,7 @@ FEATURES             Location/Qualifiers
                      /note=\"color: #ffffff\"
 "           locusName 
             totLength  // header line locus length
+            topology
             now.Day (mon.[now.Month-1]) now.Year  // header line date
             totLength  // length for REFERENCE line
             (mon.[now.Month-1]) now.Day now.Year  // Journal export date

--- a/tests/GslCore.Tests/TestDnaAssemblyTransformation.fs
+++ b/tests/GslCore.Tests/TestDnaAssemblyTransformation.fs
@@ -61,6 +61,7 @@ type Test() =
         designParams = DesignParams.initialDesignParams
         docStrings = []
         materializedFrom = emptyAssembly
+        topology = Linear
     }
 
     let runTest assembly expectedSource =


### PR DESCRIPTION
Added new pragma `#topology linear|circular` to let the user decide how the output DNAAssembly will look like: linear or circular

* This value is extracted and stampted onto the DNAAssembly upon dnacreation phase

* If the pragma is omitted, the original Linear value is used as a default

* both the Ape and Snapgene outputs are updated accordingly 

