### PR TITLE
BUG: zero is no longer accepted as a slice index

### DIFF
--- a/src/GslCore/AstProcess.fs
+++ b/src/GslCore/AstProcess.fs
@@ -427,10 +427,14 @@ let private buildRelativePosition node =
         | Int({x=i; positions=_}) -> ok i
         | x -> internalTypeMismatch (Some "relative position building") "Int" x
         >>= (fun i ->
-            match prp.qualifier with
-            | None -> buildNode (i*1<OneOffset>) FivePrime
-            | Some(q) ->
-                match q, prp.position with
+            if i = 0 then
+                error ValueError "Slice index cannot be zero" prp.i
+            else
+                let qualifier =
+                    prp.qualifier
+                    |> Option.defaultValue S
+                    
+                match qualifier, prp.position with
                 | S, _ -> buildNode (i*1<OneOffset>) FivePrime
                 | E, _ -> buildNode (i*1<OneOffset>) ThreePrime
                 | A, Left | AS, Left | SA, Left ->


### PR DESCRIPTION
Although slicing syntax uses 1 based indexing for use convenience, it allows the user to specify 0 as an index, so `foo2` and `foo5` below compiles without any issues:
```
#refgenome cenpk
#warnoff zeronine
#linkers D0,D5,D6,D9|
#platform stitch
#name foo1
gHO[1:100] // ATG...
#name foo2
gHO[0:100] // ATG..  == foo1
#name foo3
gHO[-1:100] // A ATG...
#name foo4
gHO[1AE:5AE] // AAT...
#name foo5
gHO[0AE:5AE] // AAT... == foo4
#name foo6
gHO[-1AE:5AE] // TAA ATG...
```

Not a big deal but it should disallow this and raise a compilation error such as: `Slice index cannot be zero`